### PR TITLE
docs(gpu): corriger l'API GPU (kind VMInstance, vrais modèles, gpuOperator)

### DIFF
--- a/docs/services/gpu/api-reference.md
+++ b/docs/services/gpu/api-reference.md
@@ -5,74 +5,85 @@ title: API Reference
 
 # API Reference - GPU
 
-Cette référence détaille les APIs pour utiliser les GPU sur Hikube, que ce soit avec des machines virtuelles ou des clusters Kubernetes.
+Cette référence détaille l'utilisation des GPU sur Hikube, que ce soit avec des machines virtuelles (`VMInstance`) ou des clusters Kubernetes managés (`Kubernetes`).
+
+---
+
+## 🎮 GPU disponibles
+
+Les GPU sont attachés par leur **nom de ressource** (`nvidia.com/<modèle>`). Les modèles disponibles sur Hikube :
+
+| GPU | Nom de ressource | Architecture | Mémoire | Usage typique |
+|-----|------------------|--------------|---------|---------------|
+| **L40S** | `nvidia.com/AD102GL_L40S` | Ada Lovelace | 48 Go GDDR6 | Inférence, dev, rendu |
+| **A100 PCIe 80 Go** | `nvidia.com/GA100_A100_PCIE_80GB` | Ampere | 80 Go HBM2e | Entraînement ML |
+| **A100 SXM4 80 Go** | `nvidia.com/GA100_A100_SXM4_80GB` | Ampere | 80 Go HBM2e | Entraînement ML (multi-GPU NVLink) |
+| **RTX PRO 6000 Blackwell** | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` | Blackwell | 96 Go GDDR7 | LLM, calcul intensif |
+
+:::note Disponibilité
+Le matériel GPU disponible varie selon la zone. Vérifiez les ressources allouables côté plateforme avant de planifier un workload. Le pilote NVIDIA nécessite **au moins 4 Gio de RAM** sur la VM ou le worker.
+:::
 
 ---
 
 ## 🖥️ GPU avec Machines Virtuelles
 
-### **API VirtualMachine**
+Sur une VM, le GPU est attaché en **passthrough PCI** (allocation exclusive) via le champ `gpus` d'une ressource [`VMInstance`](../compute/api-reference.md). Le disque est défini séparément par une ressource [`VMDisk`](../compute/api-reference.md#vmdisk).
 
-```yaml
+```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
-#### **Paramètres GPU pour VM**
+:::warning Pièges fréquents
+- La ressource s'appelle **`VMInstance`** (pas `VirtualMachine`).
+- L'état se pilote via **`runStrategy: Always`** (pas `running: true`).
+- Le disque n'est **pas** un champ `systemDisk` intégré : créez une ressource `VMDisk` et référencez-la dans `disks` (liste d'objets `{name}`).
+:::
+
+### Paramètres GPU pour VM
 
 | **Paramètre** | **Type** | **Description** | **Requis** |
 |---------------|----------|-----------------|------------|
-| `gpus` | `[]GPU` | Liste des GPUs à attacher | ✅ |
-| `gpus[].name` | `string` | Type de GPU NVIDIA | ✅ |
+| `gpus` | `[]object` | Liste des GPU à attacher | non |
+| `gpus[].name` | `string` | Nom de la ressource GPU (`nvidia.com/...`) | oui (si `gpus` défini) |
 
-#### **Types de GPU Disponibles**
+### Exemple VM GPU complet
 
-```yaml
-# GPU pour inférence et développement
-gpus:
-  - name: "nvidia.com/AD102GL_L40S"
-
-# GPU pour entraînement ML
-gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"
-
-# GPU pour LLM et calcul exascale
-gpus:
-  - name: "nvidia.com/H100_94GB"
-```
-
-#### **Spécifications Hardware**
-
-| **GPU** | **Architecture** | **Mémoire** | **Performance** |
-|---------|------------------|-------------|-----------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) |
-
-#### **Exemple VM GPU Complet**
-
-```yaml
+```yaml title="ai-workstation.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMDisk
+metadata:
+  name: ai-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMInstance
 metadata:
   name: ai-workstation
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.2xlarge  # 8 vCPU, 32 GB RAM
   gpus:
     - name: "nvidia.com/GA100_A100_PCIE_80GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+  disks:
+    - name: ai-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -83,37 +94,46 @@ spec:
     users:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
-    
     packages:
       - python3-pip
       - build-essential
-    
     runcmd:
-      # Pilotes NVIDIA
-      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-      - dpkg -i cuda-keyring_1.0-1_all.deb
+      # Pilotes NVIDIA + CUDA (voir le guide dédié pour la version exacte)
+      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+      - dpkg -i cuda-keyring_1.1-1_all.deb
       - apt-get update
-      - apt-get install -y cuda-toolkit nvidia-driver-535
-      
+      - apt-get install -y cuda-toolkit nvidia-driver-570
       # PyTorch avec CUDA
-      - pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+      - pip3 install torch torchvision
+```
+
+### Multi-GPU sur VM
+
+```yaml
+spec:
+  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
+  gpus:
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
 ---
 
 ## ☸️ GPU avec Kubernetes
 
-### **API Kubernetes avec GPU Workers**
+Sur un cluster Kubernetes managé, les GPU sont attachés aux **node groups**, et l'addon **`gpuOperator`** doit être activé pour exposer les GPU aux pods.
 
-```yaml
+```yaml title="cluster-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: cluster-gpu
 spec:
   controlPlane:
-    replicas: 1
-  
+    replicas: 2
+
   nodeGroups:
     gpu-workers:
       minReplicas: 1
@@ -122,16 +142,26 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Requis : installe les pilotes NVIDIA et le device plugin
+    gpuOperator:
+      enabled: true
 ```
 
-#### **Paramètres GPU pour NodeGroups**
+:::warning Addon `gpuOperator` requis
+Sans `gpuOperator: enabled: true`, les GPU des workers ne sont pas exposés aux pods (`nvidia.com/gpu` reste à 0).
+:::
+
+### Paramètres GPU pour NodeGroups
 
 | **Paramètre** | **Type** | **Description** | **Requis** |
 |---------------|----------|-----------------|------------|
-| `nodeGroups.<name>.gpus` | `[]GPU` | GPUs pour les workers | ❌ |
-| `gpus[].name` | `string` | Type de GPU NVIDIA | ✅ |
+| `nodeGroups.<name>.gpus` | `[]object` | GPU attachés aux workers du groupe | non |
+| `gpus[].name` | `string` | Nom de la ressource GPU (`nvidia.com/...`) | oui (si `gpus` défini) |
+| `addons.gpuOperator.enabled` | `boolean` | Active le NVIDIA GPU Operator | oui (pour utiliser les GPU) |
 
-#### **Configuration Multi-GPU**
+### Configuration Multi-GPU par worker
 
 ```yaml
 nodeGroups:
@@ -140,15 +170,17 @@ nodeGroups:
     maxReplicas: 2
     instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
     gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
-#### **Utilisation dans les Pods**
+### Utilisation dans les Pods
 
-```yaml
+Une fois le `gpuOperator` actif, les pods réservent les GPU via la ressource `nvidia.com/gpu` :
+
+```yaml title="ml-training.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -156,193 +188,61 @@ metadata:
 spec:
   containers:
   - name: trainer
-    image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+    image: pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
     resources:
       limits:
         nvidia.com/gpu: 1
       requests:
         nvidia.com/gpu: 1
-    command:
-      - python
-      - train.py
-```
-
-#### **Job Multi-GPU**
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: distributed-training
-spec:
-  template:
-    spec:
-      containers:
-      - name: trainer
-        image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
-        resources:
-          limits:
-            nvidia.com/gpu: 4
-          requests:
-            nvidia.com/gpu: 4
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0,1,2,3"
-      restartPolicy: Never
+    command: ["python", "train.py"]
 ```
 
 ---
 
-## 📋 Comparaison des Approches
-
-### **VM GPU vs Kubernetes GPU**
+## 📋 VM GPU vs Kubernetes GPU
 
 | **Aspect** | **VM GPU** | **Kubernetes GPU** |
 |------------|------------|-------------------|
-| **Allocation** | 1 GPU = 1 VM (exclusif) | 1+ GPU par worker (partageable) |
-| **Isolation** | Complète au niveau VM | Namespace/Pod |
-| **Scaling** | Vertical (plus de GPUs) | Horizontal + Vertical |
-| **Gestion** | Manuelle via YAML | Orchestrée par K8s |
+| **Allocation** | 1 GPU = 1 VM (passthrough exclusif) | 1+ GPU par worker |
+| **Isolation** | Complète au niveau VM | Namespace / Pod |
+| **Scaling** | Vertical (plus de GPU) | Horizontal + Vertical (autoscaling) |
+| **Gestion** | Manuelle via `VMInstance` | Orchestrée par Kubernetes |
 | **Partage** | Non | Oui (entre pods) |
-| **Overhead** | Minimal | Overhead orchestration |
+| **Overhead** | Minimal | Overhead d'orchestration |
 
-### **Quand utiliser chaque approche**
+**VM GPU** : applications non-containerisées, accès direct au GPU, dev/prototypage, rendu/CAO.
 
-#### **VM GPU recommandée pour :**
-
-- Applications legacy non-containerisées
-- Besoin d'accès direct et complet au GPU
-- Développement et prototypage
-- Workloads monolithiques
-- Applications graphiques (rendu, CAO)
-
-#### **Kubernetes GPU recommandé pour :**
-
-- Applications containerisées
-- Workloads nécessitant du scaling automatique
-- Jobs parallèles et distribués
-- Partage de ressources GPU
-- Pipelines ML/AI complexes
+**Kubernetes GPU** : workloads containerisés, autoscaling, jobs parallèles/distribués, pipelines ML/AI.
 
 ---
 
-## 🔧 Configuration Avancée
+## ✅ Vérification
 
-### **Multi-GPU sur VM**
-
-```yaml
-apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
-metadata:
-  name: multi-gpu-vm
-spec:
-  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
-  gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-```
-
-### **NodeGroup spécialisé GPU**
-
-```yaml
-nodeGroups:
-  gpu-inference:
-    minReplicas: 2
-    maxReplicas: 10
-    instanceType: "u1.large"
-    gpus:
-      - name: "nvidia.com/AD102GL_L40S"
-    
-  gpu-training:
-    minReplicas: 1
-    maxReplicas: 3
-    instanceType: "u1.4xlarge"
-    gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-```
-
-### **Pod avec GPU spécifique**
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: specific-gpu-pod
-spec:
-  nodeSelector:
-    gpu-type: "L40S"
-  containers:
-  - name: app
-    image: nvidia/cuda:12.0-runtime-ubuntu20.04
-    resources:
-      limits:
-        nvidia.com/gpu: 1
-```
-
----
-
-## ✅ Vérification et Monitoring
-
-### **Vérification VM GPU**
+### VM GPU
 
 ```bash
-# Accéder à la VM
 virtctl ssh ubuntu@vm-gpu
-
-# Vérifier les GPU
 nvidia-smi
-
-# Test CUDA
 nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
 ```
 
-### **Vérification Kubernetes GPU**
+### Kubernetes GPU
 
 ```bash
-# Voir les ressources GPU sur les nodes
-kubectl describe nodes
-
-# Vérifier l'allocation GPU
+# GPU exposés sur les nodes (nécessite gpuOperator actif)
 kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.'nvidia\.com/gpu'
 
-# Monitoring utilisation GPU
-kubectl top nodes
-```
-
-### **Monitoring GPU dans un Pod**
-
-```bash
-# Exec dans un pod avec GPU
+# Vérifier depuis un pod
 kubectl exec -it <pod-name> -- nvidia-smi
-
-# Voir les métriques GPU
-kubectl exec -it <pod-name> -- nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv -l 5
 ```
 
 ---
 
-## 💡 Bonnes Pratiques
+## 💡 Bonnes pratiques
 
-### **Pour VM GPU :**
-
-- Utilisez `replicated` storage class pour la production
-- Dimensionnez le CPU/RAM selon le GPU (ratio 8-16 vCPU par GPU)
-- Installez les pilotes NVIDIA via cloud-init
-- Arrêtez les VMs quand inutilisées pour optimiser les coûts
-
-### **Pour Kubernetes GPU :**
-
-- Configurez des resource limits appropriées
-- Utilisez nodeSelector ou nodeAffinity pour cibler des GPU spécifiques
-- Implémentez des PodDisruptionBudgets pour les workloads critiques
-- Surveillez l'utilisation GPU avec des métriques personnalisées
-
-### **Générale :**
-
-- L40S pour inférence/développement
-- A100 pour entraînement ML standard  
-- H100 pour LLM et calcul exascale
-- Testez avec L40S avant de passer aux GPU plus coûteux
+- **L40S** pour l'inférence et le développement, **A100** pour l'entraînement ML, **RTX PRO 6000 (Blackwell)** pour les workloads les plus exigeants.
+- Testez avec un L40S avant de réserver les GPU les plus coûteux.
+- Dimensionnez le CPU/RAM en fonction du GPU (≈ 8–16 vCPU par GPU) et prévoyez ≥ 4 Gio de RAM.
+- Sur VM : installez les pilotes NVIDIA via cloud-init (voir [Installer les pilotes CUDA](../compute/how-to/install-cuda-drivers.md)).
+- Sur Kubernetes : activez toujours l'addon `gpuOperator`.
+- Utilisez la `storageClass` `replicated` en production.

--- a/docs/services/gpu/concepts.md
+++ b/docs/services/gpu/concepts.md
@@ -15,7 +15,7 @@ graph TB
         subgraph "GPU physiques"
             G1[NVIDIA L40S]
             G2[NVIDIA A100]
-            G3[NVIDIA H100]
+            G3[NVIDIA RTX PRO 6000<br/>Blackwell]
         end
 
         subgraph "Allocation VM"
@@ -58,19 +58,20 @@ graph TB
 
 ## Types de GPU disponibles
 
-| GPU | Architecture | Mémoire | Performance (INT8) | Cas d'usage |
-|-----|-------------|---------|-------------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS | Inférence, développement, prototypage |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS | Entraînement ML, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS | LLM, calcul exascale, entraînement distribué |
+| GPU | Architecture | Mémoire | Cas d'usage |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inférence, développement, prototypage |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | Entraînement ML, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, calcul intensif, entraînement distribué |
 
 ### Identifiants GPU dans les manifestes
 
-| GPU | Valeur `gpus[].name` / `nvidia.com/` |
-|-----|---------------------------------------|
+| GPU | Valeur `gpus[].name` |
+|-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 Go | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 Go | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ---
 
@@ -93,8 +94,8 @@ Prévoyez **8 à 16 vCPU par GPU**. Pour un seul GPU, un `u1.2xlarge` (8 vCPU, 3
 
 Les GPU sont exposés aux pods via le **NVIDIA Device Plugin** :
 
-- Le GPU Operator doit être activé sur le cluster (`plugins.gpu-operator.enabled: true`)
-- Les pods demandent un GPU via `resources.limits` (ex: `nvidia.com/AD102GL_L40S: 1`)
+- Le GPU Operator doit être activé sur le cluster (`addons.gpuOperator.enabled: true`)
+- Les pods demandent un GPU via `resources.limits` (`nvidia.com/gpu: 1`)
 - Le scheduler Kubernetes place le pod sur un nœud disposant du GPU demandé
 - Les nœuds GPU sont configurés dans les **node groups** avec le champ `gpus[]`
 
@@ -108,7 +109,7 @@ graph LR
 
     subgraph "Pod"
         C[Container]
-        RL[resources.limits:<br/>nvidia.com/AD102GL_L40S: 1]
+        RL[resources.limits:<br/>nvidia.com/gpu: 1]
     end
 
     GPU --> DP
@@ -136,8 +137,8 @@ graph LR
 |-----------|--------|
 | GPU par VM | Multiples (selon disponibilité) |
 | GPU par pod Kubernetes | Multiples (via `resources.limits`) |
-| Types de GPU | L40S, A100, H100 |
-| Mémoire GPU max | 80 GB (A100/H100) |
+| Types de GPU | L40S, A100 (PCIe/SXM4), RTX PRO 6000 Blackwell |
+| Mémoire GPU max | 96 GB (RTX PRO 6000 Blackwell) |
 
 ---
 

--- a/docs/services/gpu/faq.md
+++ b/docs/services/gpu/faq.md
@@ -7,21 +7,22 @@ title: FAQ
 
 ### Quels modèles de GPU sont disponibles ?
 
-Hikube propose trois familles de GPU NVIDIA :
+Hikube propose plusieurs GPU NVIDIA :
 
 | GPU | Architecture | Mémoire | Cas d'usage |
 |-----|-------------|---------|-------------|
 | **L40S** | Ada Lovelace | 48 Go GDDR6 | Inférence, rendu graphique |
-| **A100** | Ampere | 80 Go HBM2e | Entraînement ML, calcul scientifique |
-| **H100** | Hopper | 80 Go HBM3 | LLM, calcul exascale |
+| **A100 (PCIe / SXM4)** | Ampere | 80 Go HBM2e | Entraînement ML, calcul scientifique |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 Go GDDR7 | LLM, calcul intensif |
 
 Les identifiants à utiliser dans les manifestes :
 
 ```yaml
 gpus:
-  - name: "nvidia.com/AD102GL_L40S"       # L40S
-  - name: "nvidia.com/GA100_A100_PCIE_80GB" # A100
-  - name: "nvidia.com/H100_94GB"           # H100
+  - name: "nvidia.com/AD102GL_L40S"                                  # L40S
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"                          # A100 PCIe
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"                          # A100 SXM4
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION" # RTX PRO 6000 Blackwell
 ```
 
 ---

--- a/docs/services/gpu/how-to/provision-gpu-kubernetes.md
+++ b/docs/services/gpu/how-to/provision-gpu-kubernetes.md
@@ -41,7 +41,16 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Requis : installe les pilotes NVIDIA et le device plugin
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` requis
+L'attachement des GPU aux node groups ne suffit pas : sans `addons.gpuOperator.enabled: true`, les pilotes NVIDIA et le device plugin ne sont pas installes dans le cluster tenant, et `nvidia.com/gpu` reste a 0 sur les nodes.
+:::
 
 :::tip
 Separez vos workloads CPU et GPU dans des node groups distincts. Cela permet un scaling independant et une meilleure maitrise des couts.
@@ -170,6 +179,10 @@ spec:
       gpus:
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
+
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 Pour cibler un node group specifique dans vos deployements, utilisez `nodeSelector` :
@@ -202,7 +215,7 @@ spec:
 ```
 
 :::note
-Les GPU disponibles pour Kubernetes sont les memes que pour les VM : **L40S** (inference/dev), **A100** (entrainement ML) et **H100** (LLM/exascale). Consultez la [reference API GPU](../api-reference.md) pour les specifications completes.
+Les GPU disponibles pour Kubernetes sont les memes que pour les VM : **L40S** (inference/dev), **A100 PCIe/SXM4** (entrainement ML) et **RTX PRO 6000 Blackwell** (LLM/calcul intensif). Consultez la [reference API GPU](../api-reference.md) pour les noms de ressources exacts et les specifications.
 :::
 
 ## Verification

--- a/docs/services/gpu/how-to/provision-gpu-vm.md
+++ b/docs/services/gpu/how-to/provision-gpu-vm.md
@@ -16,16 +16,16 @@ Hikube permet d'attacher un ou plusieurs GPU NVIDIA directement a une machine vi
 
 ### 1. Choisir le type de GPU
 
-Hikube propose trois familles de GPU NVIDIA adaptees a differents cas d'usage :
+Hikube propose plusieurs GPU NVIDIA adaptes a differents cas d'usage :
 
-| GPU | Architecture | Memoire | Performance | Cas d'usage |
-|-----|-------------|---------|-------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) | Inference, developpement, prototypage |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) | Entrainement ML, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) | LLM, calcul exascale, entrainement distribue |
+| GPU | Architecture | Memoire | Cas d'usage |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inference, developpement, prototypage |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | Entrainement ML, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, calcul intensif, entrainement distribue |
 
 :::tip Quel GPU choisir ?
-Commencez par un **L40S** pour le developpement et le prototypage. Passez a un **A100** pour l'entrainement de modeles ML standard, et reservez le **H100** pour les workloads exigeants comme l'entrainement de LLM ou le calcul haute performance.
+Commencez par un **L40S** pour le developpement et le prototypage. Passez a un **A100** pour l'entrainement de modeles ML standard, et reservez le **RTX PRO 6000 (Blackwell)** pour les workloads les plus exigeants comme l'entrainement de LLM ou le calcul haute performance.
 :::
 
 Les identifiants GPU a utiliser dans vos manifestes sont :
@@ -33,14 +33,26 @@ Les identifiants GPU a utiliser dans vos manifestes sont :
 | GPU | Valeur `gpus[].name` |
 |-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 Go | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 Go | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ### 2. Creer le manifeste de la VM avec GPU
 
 Creez un manifeste qui declare le GPU souhaite dans la section `spec.gpus` :
 
 ```yaml title="gpu-vm.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: gpu-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 100Gi
+  storageClass: replicated
+---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -51,9 +63,8 @@ spec:
   instanceType: u1.2xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 100Gi
-    storageClass: replicated
+  disks:
+    - name: gpu-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -132,6 +143,17 @@ Pour les workloads intensifs (entrainement distribue, inference a grande echelle
 
 ```yaml title="multi-gpu-vm.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: multi-gpu-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
   name: multi-gpu-workstation
@@ -140,13 +162,12 @@ spec:
   instanceProfile: ubuntu
   instanceType: u1.8xlarge
   gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+  disks:
+    - name: multi-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:

--- a/docs/services/gpu/overview.md
+++ b/docs/services/gpu/overview.md
@@ -39,28 +39,28 @@ Les GPU peuvent être alloués aux workers Kubernetes et ensuite assignés aux p
 
 ## 🖥️ Hardware Disponible
 
-Hikube propose trois types de GPU NVIDIA :
+Hikube propose plusieurs GPU NVIDIA :
 
 ### **NVIDIA L40S**
 
 - **Architecture** : Ada Lovelace
 - **Mémoire** : 48 GB GDDR6 avec ECC
-- **Performance** : 362 TOPS (INT8), 91.6 TFLOPs (FP32)
+- **Nom de ressource** : `nvidia.com/AD102GL_L40S`
 - **Usage typique** : IA générative, inférence, rendu temps réel
 
-### **NVIDIA A100**
+### **NVIDIA A100 80 Go (PCIe / SXM4)**
 
 - **Architecture** : Ampere
 - **Mémoire** : 80 GB HBM2e avec ECC
-- **Performance** : 312 TOPS (INT8), 624 TFLOPs (Tensor)
-- **Usage typique** : Entraînement ML, calcul haute performance
+- **Noms de ressource** : `nvidia.com/GA100_A100_PCIE_80GB`, `nvidia.com/GA100_A100_SXM4_80GB`
+- **Usage typique** : Entraînement ML, calcul haute performance (la variante SXM4 supporte NVLink pour le multi-GPU)
 
-### **NVIDIA H100**
+### **NVIDIA RTX PRO 6000 Blackwell**
 
-- **Architecture** : Hopper
-- **Mémoire** : 80 GB HBM3 avec ECC
-- **Performance** : 1979 TOPS (INT8), 989 TFLOPs (Tensor)
-- **Usage typique** : LLM, transformers, calcul exascale
+- **Architecture** : Blackwell (Server Edition)
+- **Mémoire** : 96 GB GDDR7 avec ECC
+- **Nom de ressource** : `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`
+- **Usage typique** : LLM, transformers, calcul intensif
 
 ---
 
@@ -74,7 +74,7 @@ flowchart TD
         subgraph NODE["Nœud Physique"]
             GPU1["🎮 GPU L40S"]
             GPU2["🎮 GPU A100"]
-            GPU3["🎮 GPU H100"]
+            GPU3["🎮 GPU RTX PRO 6000"]
         end
         
         subgraph VM1["VM Instance"]
@@ -131,11 +131,14 @@ flowchart TD
 
 ```yaml
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 spec:
+  runStrategy: Always
   instanceType: "u1.xlarge"
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
 ### **GPU sur Kubernetes Worker**
@@ -149,6 +152,9 @@ spec:
       instanceType: "u1.xlarge"
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 ### **GPU dans Pod Kubernetes**

--- a/docs/services/gpu/quick-start.md
+++ b/docs/services/gpu/quick-start.md
@@ -42,18 +42,17 @@ spec:
 
 ```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu-example
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge  # 4 vCPU, 16 GB RAM
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 50Gi
-    storageClass: replicated
+  disks:
+    - name: ubuntu-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -89,7 +88,7 @@ kubectl apply -f vm-disk.yaml
 kubectl apply -f vm-gpu.yaml
 
 # Vérifier l'état
-kubectl get virtualmachine vm-gpu-example
+kubectl get vminstance vm-gpu-example
 ```
 
 ### **Étape 4 : Accéder et tester**
@@ -133,9 +132,19 @@ spec:
       maxReplicas: 2
       instanceType: "s1.medium"
       ephemeralStorage: 50Gi
-  
+
   storageClass: "replicated"
+
+  addons:
+    # Indispensable : installe les pilotes NVIDIA et le device plugin
+    # qui exposent nvidia.com/gpu aux pods du cluster tenant
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` requis
+Sans l'addon `gpuOperator` activé, les GPU attachés aux workers ne sont **pas** exposés aux pods (`nvidia.com/gpu` reste à 0). Il installe les pilotes NVIDIA et le device plugin dans le cluster tenant.
+:::
 
 ### **Étape 2 : Déployer le cluster**
 
@@ -211,13 +220,15 @@ kubectl exec -it gpu-test -- nvidia-smi
 gpus:
   - name: "nvidia.com/AD102GL_L40S"  # 48 GB GDDR6
 
-# Pour entraînement ML
+# Pour entraînement ML (A100, deux variantes selon le matériel)
 gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e (PCIe)
+  # ou
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"  # 80 GB HBM2e (SXM4)
 
 # Pour LLM/calcul exascale
 gpus:
-  - name: "nvidia.com/H100_94GB"  # 80 GB HBM3
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"  # 96 GB GDDR7
 ```
 
 ---
@@ -285,7 +296,7 @@ Ces actions suppriment les ressources GPU et toutes les données associées. Ces
 
 - **VM GPU** : Idéal pour prototypage et applications legacy
 - **Kubernetes GPU** : Recommandé pour workloads de production scalables
-- Commencez par **L40S** pour tester avant d'utiliser A100/H100
+- Commencez par **L40S** pour tester avant d'utiliser A100 ou RTX PRO 6000 (Blackwell)
 - Utilisez `replicated` storage class pour la production
 
 <NavigationFooter


### PR DESCRIPTION
## Contexte

La section GPU (la plus critique pour le client IaC) décrivait une API et un parc matériel qui ne correspondent pas à la production Hikube. Corrections vérifiées contre les `permittedHostDevices` de KubeVirt et les ressources allouables des nœuds.

## Corrections majeures

- **`kind: VirtualMachine` → `VMInstance`** — la ressource `VirtualMachine` **n'existe pas** dans l'API Hikube
- `running: true` → **`runStrategy: Always`**
- `systemDisk: {size, storageClass}` (inexistant) → ressource **`VMDisk`** séparée + `disks: [{name}]`

## Matériel GPU (vérifié sur les nœuds)

| Doc avant | Réalité prod |
|---|---|
| L40S, A100, **H100** | L40S, A100 PCIe, **A100 SXM4**, **RTX PRO 6000 Blackwell** |

- ❌ Le **H100** (`nvidia.com/H100_94GB`) **n'existe pas** sur le parc → supprimé partout
- ➕ Ajout : `nvidia.com/GA100_A100_SXM4_80GB` et `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`

## Kubernetes GPU

- Documentation de l'**addon `gpuOperator`** (requis) — sans lui, `nvidia.com/gpu` reste à `0` sur les nodes
- Correction de la clé `plugins.gpu-operator.enabled` → **`addons.gpuOperator.enabled`**
- Requête pod corrigée : `nvidia.com/gpu: 1` (et non le nom de device par modèle, valable uniquement pour le passthrough VM)

## Fichiers (7)

`api-reference.md`, `quick-start.md`, `concepts.md`, `overview.md`, `faq.md`, `how-to/provision-gpu-vm.md`, `how-to/provision-gpu-kubernetes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)