### PR TITLE
docs(kubernetes): référence API complète + champs corrigés

### DIFF
--- a/docs/services/kubernetes/api-reference.md
+++ b/docs/services/kubernetes/api-reference.md
@@ -3,205 +3,294 @@ sidebar_position: 6
 title: API Reference
 ---
 
-# Exemples Complets
+# API Reference – Kubernetes
 
-## **Cluster de Production**
+Cette référence décrit l'API **`Kubernetes`** d'Hikube (`apps.cozystack.io/v1alpha1`), qui provisionne des clusters Kubernetes managés (control plane Kamaji + workers KubeVirt). Les champs ci-dessous correspondent au schéma réellement exposé par la plateforme.
+
+```yaml title="cluster.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kubernetes
+metadata:
+  name: my-cluster
+spec:
+  version: v1.35
+  storageClass: replicated
+  controlPlane:
+    replicas: 2
+  nodeGroups:
+    md0:
+      minReplicas: 1
+      maxReplicas: 5
+      instanceType: u1.medium
+      ephemeralStorage: 20Gi
+      roles:
+        - ingress-nginx
+  addons:
+    ingressNginx:
+      enabled: true
+```
+
+---
+
+## Spécification
+
+| Paramètre       | Type      | Description                                                            | Défaut       |
+| --------------- | --------- | --------------------------------------------------------------------- | ------------ |
+| `version`       | `string`  | Version Kubernetes (`major.minor`) — voir [versions](#version)        | `v1.35`      |
+| `storageClass`  | `string`  | Classe de stockage pour les volumes persistants                       | `replicated` |
+| `host`          | `string`  | Nom d'hôte externe du cluster. Par défaut `<cluster>.<tenant-host>`   | `""`         |
+| `controlPlane`  | `object`  | Configuration du plan de contrôle — voir [Concepts](concepts.md#control-plane) | `{}` |
+| `nodeGroups`    | `object`  | Carte des groupes de workers — voir [nodeGroups](#nodegroups)          | voir défaut  |
+| `addons`        | `object`  | Modules complémentaires du cluster — voir [addons](#addons)           | `{}`         |
+
+---
+
+## version
+
+`version` sélectionne la version mineure de Kubernetes à déployer.
+
+| Valeurs supportées |
+| ------------------ |
+| `v1.35` (défaut), `v1.34`, `v1.33`, `v1.32`, `v1.31`, `v1.30` |
+
+```yaml
+spec:
+  version: v1.34
+```
+
+Voir le guide [Mettre à jour un cluster](how-to/upgrade-cluster.md) pour la montée de version.
+
+---
+
+## nodeGroups
+
+`nodeGroups` est une **carte** (`<nom>: {…}`) décrivant les groupes de workers. Chaque groupe est autoscalé entre `minReplicas` et `maxReplicas`.
+
+| Champ              | Type            | Description                                                       | Défaut      |
+| ------------------ | --------------- | ----------------------------------------------------------------- | ----------- |
+| `minReplicas`      | `integer`       | Nombre minimal de nœuds (0 = scale-to-zero possible)              | `0`         |
+| `maxReplicas`      | `integer`       | Nombre maximal de nœuds                                           | `10`        |
+| `instanceType`     | `string`        | Gabarit des nœuds (voir [types d'instances](../compute/api-reference.md#types-dinstances)) | `u1.medium` |
+| `ephemeralStorage` | `int`/`string`  | Taille du stockage éphémère par nœud (ex : `20Gi`)               | `20Gi`      |
+| `resources`        | `object`        | Surcharge explicite `cpu` / `memory` par nœud                    | `{}`        |
+| `gpus`             | `[]object`      | GPU attachés aux nœuds (`gpus[].name`) — voir [GPU](../gpu/api-reference.md#-gpu-avec-kubernetes) | `[]` |
+| `roles`            | `[]string`      | Rôles des nœuds (ex : `ingress-nginx`)                            | `[]`        |
+
+:::note `ephemeralStorage` est un scalaire
+Indiquez directement une taille (`ephemeralStorage: 20Gi`), pas un objet `{size: …}`.
+:::
+
+```yaml
+spec:
+  nodeGroups:
+    workers:
+      minReplicas: 1
+      maxReplicas: 10
+      instanceType: u1.xlarge
+      ephemeralStorage: 50Gi
+      roles:
+        - ingress-nginx
+    gpu-workers:
+      minReplicas: 0
+      maxReplicas: 4
+      instanceType: u1.2xlarge
+      ephemeralStorage: 200Gi
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
+```
+
+Voir [Concepts → Node Groups](concepts.md#node-groups) pour le détail des champs.
+
+---
+
+## addons
+
+Le bloc `addons` active les modules complémentaires installés dans le cluster tenant. La plupart exposent `enabled` et `valuesOverride` (surcharge de valeurs Helm).
+
+| Addon                  | Champs                                          | Rôle                                                      |
+| ---------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `certManager`          | `enabled`, `valuesOverride`                     | Gestion automatique des certificats TLS                   |
+| `ingressNginx`         | `enabled`, `exposeMethod`, `hosts`, `valuesOverride` | Contrôleur Ingress NGINX (voir ci-dessous)           |
+| `fluxcd`               | `enabled`, `valuesOverride`                     | GitOps (Flux)                                             |
+| `gatewayAPI`           | `enabled`                                       | Support de la Gateway API                                 |
+| `gpuOperator`          | `enabled`, `valuesOverride`                     | NVIDIA GPU Operator (**requis** pour les workers GPU)     |
+| `monitoringAgents`     | `enabled`, `valuesOverride`                     | Agents de monitoring/logs                                 |
+| `velero`               | `enabled`, `valuesOverride`                     | Sauvegarde / restauration                                 |
+| `cilium`               | `valuesOverride`                                | CNI Cilium (toujours actif, surcharge uniquement)         |
+| `coredns`              | `valuesOverride`                                | CoreDNS (toujours actif, surcharge uniquement)            |
+| `verticalPodAutoscaler`| `valuesOverride`                                | Vertical Pod Autoscaler (toujours actif)                  |
+
+:::note
+`cilium`, `coredns` et `verticalPodAutoscaler` n'ont pas de champ `enabled` (composants de base) — seul `valuesOverride` est exploitable. `gatewayAPI` n'expose que `enabled`.
+:::
+
+### certManager / fluxcd / velero / monitoringAgents / gpuOperator
+
+```yaml
+spec:
+  addons:
+    certManager:
+      enabled: true
+    gpuOperator:
+      enabled: true     # indispensable si des nodeGroups portent des gpus
+    velero:
+      enabled: true
+    monitoringAgents:
+      enabled: true
+    fluxcd:
+      enabled: true
+```
+
+### ingressNginx
+
+| Champ            | Type       | Description                                                                  | Défaut     |
+| ---------------- | ---------- | ---------------------------------------------------------------------------- | ---------- |
+| `enabled`        | `boolean`  | Active le contrôleur (nécessite des nœuds avec le rôle `ingress-nginx`)      | `false`    |
+| `exposeMethod`   | `string`   | Méthode d'exposition : `Proxied` ou `LoadBalancer`                          | `Proxied`  |
+| `hosts`          | `[]string` | Domaines routés vers ce cluster lorsque `exposeMethod: Proxied`             | `[]`       |
+| `valuesOverride` | `object`   | Surcharge de valeurs Helm                                                    | `{}`       |
+
+```yaml
+spec:
+  addons:
+    ingressNginx:
+      enabled: true
+      exposeMethod: Proxied
+      hosts:
+        - app.example.com
+        - "*.services.example.com"
+```
+
+---
+
+## Exemples complets
+
+### Cluster de production
 
 ```yaml title="production-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: production
-  namespace: company-prod
-  labels:
-    environment: production
-    criticality: high
-    team: platform
 spec:
-  # Configuration cluster
-  host: "k8s-prod.company.com"
-  storageClass: "replicated"
+  version: v1.34
+  storageClass: replicated
+  host: k8s-prod.example.com
 
-  # Plan de contrôle haute disponibilité
   controlPlane:
     replicas: 3
 
-  # Node groups spécialisés
   nodeGroups:
-    # Nœuds généraux avec Ingress
     web:
       minReplicas: 3
       maxReplicas: 10
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Nœuds compute pour workloads intensifs
     compute:
       minReplicas: 1
       maxReplicas: 5
-      instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
+      instanceType: u1.4xlarge
       ephemeralStorage: 100Gi
       roles: []
 
-    # Nœuds monitoring dédiés
-    monitoring:
-      minReplicas: 2
-      maxReplicas: 4
-      instanceType: "m1.xlarge"   # 4 vCPU, 32 GB RAM
-      ephemeralStorage: 200Gi
-      roles:
-        - monitoring
-
-  # Add-ons complets
   addons:
-    # Certificats SSL automatiques
     certManager:
       enabled: true
-      valuesOverride:
-        prometheus:
-          enabled: true
-
-    # Exposition HTTP/HTTPS
     ingressNginx:
       enabled: true
+      exposeMethod: Proxied
       hosts:
-        - "app.company.com"
-        - "api.company.com"
-        - "*.services.company.com"
-      valuesOverride:
-        controller:
-          replicaCount: 3
-          resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
-
-    # GitOps pour déploiements
+        - app.example.com
+        - api.example.com
     fluxcd:
       enabled: true
-      valuesOverride:
-        gitRepository:
-          url: "https://github.com/company/k8s-production"
-          branch: "main"
-
-    # Monitoring complet
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        fluentbit:
-          enabled: true
+    velero:
+      enabled: true
 ```
 
-## **Cluster de Développement**
+### Cluster de développement
 
 ```yaml title="development-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: development
-  namespace: company-dev
-  labels:
-    environment: development
-    auto-cleanup: "7d"
 spec:
-  # Configuration basique
-  host: "k8s-dev.company.local"
-  storageClass: "replicated"
+  storageClass: replicated
 
-  # Plan de contrôle minimal
   controlPlane:
-    replicas: 1  # Économie de ressources
+    replicas: 1   # économie de ressources (pas de HA)
 
-  # Node group unique polyvalent
   nodeGroups:
     general:
       minReplicas: 1
       maxReplicas: 3
-      instanceType: "s1.medium"
+      instanceType: s1.medium
       ephemeralStorage: 30Gi
       roles:
         - ingress-nginx
 
-  # Add-ons essentiels uniquement
   addons:
     certManager:
       enabled: true
-
     ingressNginx:
       enabled: true
       hosts:
-        - "*.dev.company.local"
-      valuesOverride:
-        controller:
-          replicaCount: 1  # Réplication minimale
+        - "*.dev.example.com"
 ```
 
-## **Cluster ML/AI avec GPU**
+### Cluster ML/AI avec GPU
 
 ```yaml title="ml-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: machine-learning
-  namespace: company-ai
-  labels:
-    environment: ai
-    workload: gpu
 spec:
-  host: "k8s-ai.company.com"
-  storageClass: "fast-ssd"  # Stockage haute performance
+  storageClass: replicated
 
   controlPlane:
     replicas: 2
 
   nodeGroups:
-    # Nœuds standard pour orchestration
     system:
       minReplicas: 2
       maxReplicas: 4
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Nœuds GPU pour ML workloads
     gpu:
-      minReplicas: 0      # Scaling à zéro possible
+      minReplicas: 0          # scale-to-zero hors charge
       maxReplicas: 10
-      instanceType: "u1.2xlarge"
-      gpus: # Instance avec GPU
-        - name: nvidia.com/AD102GL_L40S # Nvidia L40S
-      ephemeralStorage: 500Gi      # Stockage important pour datasets
+      instanceType: u1.2xlarge
+      ephemeralStorage: 500Gi # datasets
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
       roles: []
 
   addons:
     certManager:
       enabled: true
-
+    # Requis pour exposer les GPU aux pods (nvidia.com/gpu)
+    gpuOperator:
+      enabled: true
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        # Monitoring spécialisé GPU
-        dcgmExporter:
-          enabled: true
 ```
 
----
-
-:::tip 💡 Bonnes Pratiques
-
-- **Utilisez des labels** pour organiser vos clusters par environnement
-- **Configurez RBAC** dès la création pour sécuriser l'accès
-- **Activez le monitoring** pour une observabilité complète
-- **Planifiez la capacité** avec des node groups appropriés
-- **Testez les sauvegardes** régulièrement
+:::tip Bonnes pratiques
+- `controlPlane.replicas: 3` en production (quorum etcd / HA).
+- Séparez les workloads dans des node groups dédiés (web, compute, GPU).
+- Pour les GPU : node group avec `gpus` **et** `addons.gpuOperator.enabled: true`.
+- Activez le monitoring et les sauvegardes (Velero) sur les clusters critiques.
 :::
 
-:::warning ⚠️ Attention
-
-- **Les suppressions sont irréversibles** - pensez aux sauvegardes
-- **Les mises à jour** peuvent avoir un impact sur les workloads
-- **Vérifiez la compatibilité** des add-ons avec les versions Kubernetes
+:::warning Attention
+- Les suppressions de cluster sont **irréversibles** — vérifiez vos sauvegardes.
+- Sans l'addon `gpuOperator`, les GPU attachés aux workers ne sont pas exposés aux pods.
 :::

--- a/docs/services/kubernetes/api-reference.md
+++ b/docs/services/kubernetes/api-reference.md
@@ -73,7 +73,7 @@ Voir le guide [Mettre à jour un cluster](how-to/upgrade-cluster.md) pour la mon
 | `instanceType`     | `string`        | Gabarit des nœuds (voir [types d'instances](../compute/api-reference.md#types-dinstances)) | `u1.medium` |
 | `ephemeralStorage` | `int`/`string`  | Taille du stockage éphémère par nœud (ex : `20Gi`)               | `20Gi`      |
 | `resources`        | `object`        | Surcharge explicite `cpu` / `memory` par nœud                    | `{}`        |
-| `gpus`             | `[]object`      | GPU attachés aux nœuds (`gpus[].name`) — voir [GPU](../gpu/api-reference.md#-gpu-avec-kubernetes) | `[]` |
+| `gpus`             | `[]object`      | GPU attachés aux nœuds (`gpus[].name`) — voir [GPU avec Kubernetes](../gpu/api-reference.md) | `[]` |
 | `roles`            | `[]string`      | Rôles des nœuds (ex : `ingress-nginx`)                            | `[]`        |
 
 :::note `ephemeralStorage` est un scalaire

--- a/docs/services/kubernetes/concepts.md
+++ b/docs/services/kubernetes/concepts.md
@@ -216,13 +216,12 @@ Le champ `nodeGroup` définit la configuration d'un groupe de nœuds (workers) a
 Il permet de spécifier le type d'instance, les ressources, le nombre de réplicas, ainsi que les rôles et les GPU associés.
 
 ```yaml title="node-group.yaml"
-nodeGroup:
+nodeGroups:
   <name>:
-    ephemeralStorage:
-      size: 100Gi
+    ephemeralStorage: 100Gi
     gpus:
       - name: nvidia.com/AD102GL_L40S
-    instanceType: m5.large
+    instanceType: u1.xlarge
     maxReplicas: 5
     minReplicas: 2
     resources:
@@ -234,10 +233,10 @@ nodeGroup:
 
 ---
 
-### `ephemeralStorage` (Object)
+### `ephemeralStorage` (string)
 
-Définit la configuration du **stockage éphémère** associé aux nœuds du groupe.
-Ce stockage est utilisé pour les données temporaires, les caches ou les fichiers de logs.
+Définit la taille du **stockage éphémère** par nœud du groupe (ex : `100Gi`).
+Ce stockage est utilisé pour les données temporaires, les caches ou les fichiers de logs. C'est une valeur scalaire (pas un objet `{size: …}`).
 
 ### `gpus` (Array)
 


### PR DESCRIPTION
## Contexte

L'« API Reference » Kubernetes ne contenait que des exemples (sans table de champs) et utilisait une storageClass inexistante. Mise à jour d'après le schéma réel de la ressource `Kubernetes` (`apps.cozystack.io/v1alpha1`).

## Corrections

- **Référence de champs** ajoutée pour le spec top-level : `version`, `host`, `storageClass`, `nodeGroups`, `controlPlane`, `addons`
- `version` : enum réel **`v1.30` → `v1.35`** (défaut `v1.35`)
- **Catalogue complet des `addons`** (le gros manque) :
  - `certManager`, `ingressNginx` (avec `exposeMethod: Proxied|LoadBalancer` + `hosts`), `fluxcd`, `gatewayAPI`, **`gpuOperator`**, `monitoringAgents`, `velero`
  - `cilium` / `coredns` / `verticalPodAutoscaler` : pas de champ `enabled` (composants de base), `valuesOverride` uniquement
- **`gpuOperator`** mis en avant comme requis pour les node groups GPU
- ❌ storageClass `fast-ssd` (inexistante) → `replicated`
- `nodeGroups.<n>.ephemeralStorage` : **scalaire** (`20Gi`), et non `{size: …}`

## concepts.md

- Exemple node-group corrigé : `ephemeralStorage` scalaire, `instanceType: u1.xlarge` (le `m5.large` était un nommage AWS inexistant sur Hikube)

🤖 Generated with [Claude Code](https://claude.com/claude-code)