### PR TITLE
docs(terraform): corriger les exemples IaC VM/VMDisk et cluster

### DIFF
--- a/docs/tools/terraform.md
+++ b/docs/tools/terraform.md
@@ -80,22 +80,32 @@ resource "kubectl_manifest" "kubernetes_cluster" {
       namespace = "default"
     }
     spec = {
+      version      = "v1.34"
+      storageClass = "replicated"
+
       controlPlane = {
         replicas = 2
       }
-      
+
       nodeGroups = {
         general = {
           minReplicas      = 1
           maxReplicas      = 5
           instanceType     = "s1.large"
           ephemeralStorage = "50Gi"
-          roles = ["ingress-nginx"]
+          roles            = ["ingress-nginx"]
         }
+        # Exemple de groupe GPU (nécessite l'addon gpuOperator ci-dessous)
+        # gpu = {
+        #   minReplicas      = 0
+        #   maxReplicas      = 4
+        #   instanceType     = "u1.2xlarge"
+        #   ephemeralStorage = "200Gi"
+        #   gpus             = [{ name = "nvidia.com/AD102GL_L40S" }]
+        #   roles            = []
+        # }
       }
-      
-      storageClass = "replicated"
-      
+
       addons = {
         certManager = {
           enabled = true
@@ -106,6 +116,10 @@ resource "kubectl_manifest" "kubernetes_cluster" {
             "${var.cluster_name}.example.com"
           ]
         }
+        # Requis pour exposer les GPU aux pods d'un node group GPU
+        # gpuOperator = {
+        #   enabled = true
+        # }
       }
     }
   })
@@ -134,29 +148,52 @@ resource "local_file" "kubeconfig" {
 ### Déployer une Machine Virtuelle
 
 ```hcl title="virtual-machine.tf"
-resource "kubectl_manifest" "virtual_machine" {
+# Le disque est une ressource VMDisk distincte, référencée par la VM
+resource "kubectl_manifest" "vm_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "${var.vm_name}-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "50Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "virtual_machine" {
+  depends_on = [kubectl_manifest.vm_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = var.vm_name
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
-      
-      systemDisk = {
-        size         = "50Gi"
-        storageClass = "replicated"
-      }
-      
+
+      disks = [
+        {
+          name = "${var.vm_name}-disk"
+        }
+      ]
+
       external       = true
       externalMethod = "PortList"
       externalPorts  = [22, 80, 443]
-      
+
       sshKeys = [var.ssh_public_key]
-      
+
       cloudInit = <<-EOT
         #cloud-config
         users:
@@ -186,35 +223,59 @@ resource "kubectl_manifest" "virtual_machine" {
 ### Déployer une VM avec GPU
 
 ```hcl title="vm-gpu.tf"
-resource "kubectl_manifest" "vm_gpu" {
+resource "kubectl_manifest" "vm_gpu_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "gpu-vm-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "100Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "vm_gpu" {
+  depends_on = [kubectl_manifest.vm_gpu_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = "gpu-vm"
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
-      
+
       gpus = [
         {
+          # Modèles : nvidia.com/AD102GL_L40S, nvidia.com/GA100_A100_PCIE_80GB,
+          # nvidia.com/GA100_A100_SXM4_80GB, nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION
           name = "nvidia.com/AD102GL_L40S"
         }
       ]
-      
-      systemDisk = {
-        size         = "100Gi"
-        storageClass = "replicated"
-      }
-      
+
+      disks = [
+        {
+          name = "gpu-vm-disk"
+        }
+      ]
+
       external       = true
       externalMethod = "PortList"
       externalPorts  = [22, 8888]
-      
+
       sshKeys = [var.ssh_public_key]
-      
+
       cloudInit = <<-EOT
         #cloud-config
         users:
@@ -295,7 +356,7 @@ output "cluster_kubeconfig" {
 
 output "vm_status" {
   description = "Commande pour vérifier le statut de la VM"
-  value       = "kubectl get virtualmachine ${var.vm_name}"
+  value       = "kubectl get vminstance ${var.vm_name}"
 }
 
 output "postgres_connection" {


### PR DESCRIPTION
## Contexte

Les exemples Terraform (page IaC) produisaient des manifestes **invalides** : ils utilisaient une API VM inexistante. C'est précisément le chemin emprunté par un client qui pilote ses VMs (dont GPU) en IaC, donc le plus impactant à corriger.

## Corrections

- `kind = "VirtualMachine"` → **`VMInstance`**
- `running = true` → `runStrategy = "Always"`
- `systemDisk = { size, storageClass }` (champ inexistant) → ressource **`VMDisk`** distincte (`kubectl_manifest.vm_disk`) référencée par `disks = [{ name = … }]`, avec `depends_on`
- VM GPU : mêmes corrections + noms de ressources GPU réels documentés en commentaire (L40S, A100 PCIe/SXM4, RTX PRO 6000 Blackwell)
- Cluster Kubernetes : ajout du champ `version`, plus exemples commentés d'un node group GPU et de l'addon `gpuOperator`
- Output : `kubectl get virtualmachine` → `kubectl get vminstance`

> Les autres exemples (PostgreSQL) sont inchangés : `spec.size` y est le champ correct du chart Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)