### PR TITLE
docs(i18n): synchroniser les traductions en/de/it (VM, GPU, Kubernetes, Terraform)

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
@@ -5,7 +5,9 @@ title: API-Referenz
 
 ## API-Referenz – Virtuelle Maschinen
 
-Diese Referenz beschreibt umfassend die **VMInstance**- und **VMDisk**-APIs von Hikube: verfügbare Parameter, Verwendungsbeispiele und empfohlene Best Practices.
+Diese Referenz beschreibt umfassend die **VMInstance**- und **VMDisk**-APIs von Hikube: verfügbare Parameter, Standardwerte, Verwendungsbeispiele und empfohlene Best Practices.
+
+Die unten dokumentierten Felder entsprechen dem tatsächlich von der Plattform exponierten Schema (`apps.cozystack.io/v1alpha1`).
 
 ---
 
@@ -13,9 +15,9 @@ Diese Referenz beschreibt umfassend die **VMInstance**- und **VMDisk**-APIs von 
 
 ### Übersicht
 
-Die `VMInstance`-API ermöglicht das Erstellen, Konfigurieren und Verwalten von virtuellen Maschinen in Hikube.
+Die `VMInstance`-API ermöglicht das Erstellen, Konfigurieren und Verwalten von virtuellen Maschinen in Hikube. Eine VM stützt sich auf eine oder mehrere Festplatten, die separat über die Ressource [`VMDisk`](#vmdisk) beschrieben werden.
 
-```yaml
+```yaml title="vm-instance.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -24,24 +26,60 @@ spec:
   # Detaillierte Konfiguration unten
 ```
 
+:::warning Korrektes Kind
+Die Ressource heißt **`VMInstance`** (und nicht `VirtualMachine`). Die Festplatte ist **kein** integriertes Feld `systemDisk`: Sie müssen eine separate Ressource `VMDisk` erstellen und sie in `disks` referenzieren.
+:::
+
 ---
 
 ### Vollständige Spezifikation
 
-#### Allgemeine Parameter
+| Parameter         | Typ              | Beschreibung                                                                | Standard     | Erforderlich |
+| ----------------- | ---------------- | --------------------------------------------------------------------------- | ------------ | ------------ |
+| `external`        | `boolean`        | Aktiviert die Netzwerk-Exposition von außerhalb des Clusters                | `false`      | nein         |
+| `externalMethod`  | `string`         | Expositionsmethode: `PortList` oder `WholeIP`                               | `PortList`   | nein         |
+| `externalPorts`   | `[]integer`      | Von außen weiterzuleitende Ports (verwendet mit `PortList`)                 | `[22]`       | nein         |
+| `runStrategy`     | `string`         | Gewünschter Ausführungszustand (siehe [runStrategy](#runstrategy))          | `Always`     | nein         |
+| `instanceType`    | `string`         | CPU-/Speicher-Vorlage (siehe [Instanztypen](#instanztypen))                 | `u1.medium`  | nein         |
+| `instanceProfile` | `string`         | OS-Profil / Präferenzen (Treiber, Kernel) — siehe [Profile](#os-profile)    | `ubuntu`     | nein         |
+| `disks`           | `[]object`       | Liste der anzuhängenden `VMDisk` (siehe [disks](#festplatten))              | `[]`         | nein         |
+| `subnets`         | `[]object`       | Zusätzliche Subnetze (VPC) — siehe [subnets](#subnetze)                     | `[]`         | nein         |
+| `gpus`            | `[]object`       | Im Passthrough anzuhängende GPUs (siehe [gpus](#gpu))                        | `[]`         | nein         |
+| `resources`       | `object`         | Explizite Überschreibung von CPU / Speicher / Sockets (siehe [resources](#ressourcen)) | `{}` | nein   |
+| `cpuModel`        | `string`         | Der VM exponiertes CPU-Modell (z.B.: `host-passthrough`)                    | `""`         | nein         |
+| `sshKeys`         | `[]string`       | Injizierte öffentliche SSH-Schlüssel                                        | `[]`         | nein         |
+| `cloudInit`       | `string`         | Cloud-init-Konfiguration (user-data YAML)                                   | `""`         | nein         |
+| `cloudInitSeed`   | `string`         | Seed zur Generierung einer stabilen SMBIOS-UUID                             | `""`         | nein         |
 
-| Parameter         | Typ        | Beschreibung                                 | Standard   | Erforderlich |
-| ----------------- | ---------- | -------------------------------------------- | ---------- | ------------ |
-| `external`        | `boolean`  | Aktiviert die externe Netzwerk-Exposition der VM | `false`    | ✅            |
-| `externalMethod`  | `string`   | Expositionsmethode (`PortList`, `WholeIP`)   | `PortList` | ✅            |
-| `externalPorts`   | `[]int`    | Extern exponierte Ports                      | `[]`       | ✅            |
-| `running`         | `boolean`  | Gewünschter Zustand der VM                   | `true`     | ✅            |
-| `instanceType`    | `string`   | CPU/Speicher-Vorlage                         | –          | ✅            |
-| `instanceProfile` | `string`   | OS-Profil der VM                             | –          | ✅            |
-| `disks`           | `[]string` | Liste der angehängten `VMDisk`               | `[]`       | ✅            |
-| `sshKeys`         | `[]string` | Injizierte öffentliche SSH-Schlüssel         | `[]`       | ✅            |
-| `cloudInit`       | `string`   | Cloud-init-Konfiguration (YAML)              | `""`       | ✅            |
-| `cloudInitSeed`   | `string`   | Cloud-init-Seed-Daten                        | `""`       | ✅            |
+:::note
+Alle Felder sind optional: Eine minimale VM benötigt nur eine in `disks` referenzierte bootfähige Festplatte. Die obigen Standardwerte sind diejenigen, die von der Plattform angewendet werden.
+:::
+
+---
+
+### runStrategy
+
+`runStrategy` steuert den Ausführungszustand der VM. Es ersetzt das frühere boolesche Feld `running`.
+
+| Wert              | Verhalten                                                               |
+| ----------------- | ----------------------------------------------------------------------- |
+| `Always`          | Die VM wird gestartet gehalten (startet automatisch neu, wenn sie stoppt) |
+| `Halted`          | Die VM ist gestoppt                                                     |
+| `Manual`          | Der Zustand wird manuell gesteuert (`virtctl start` / `stop`)           |
+| `RerunOnFailure`  | Startet nur nach einem Fehlschlag neu                                   |
+| `Once`            | Startet ein einziges Mal, ohne automatischen Neustart                   |
+
+```yaml
+spec:
+  runStrategy: Always
+```
+
+Um eine bestehende VM zu stoppen/neu zu starten:
+
+```bash
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Halted"}}'
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Always"}}'
+```
 
 ---
 
@@ -57,29 +95,22 @@ spec:
     - 443
 ```
 
+Siehe [Netzwerk-Expositionsmethoden](#netzwerk-expositionsmethoden).
+
 ---
 
 ### Instanztypen
 
-#### Serie S – Standard (Verhältnis 1:2)
+`instanceType` referenziert einen `VirtualMachineClusterInstancetype`. Hikube exponiert mehrere Serien, jeweils mit den Größen `nano` → `8xlarge`:
 
-Allgemeine Workloads, geteilte und burstable CPUs.
-
-```yaml
-instanceType: s1.small     # 1 vCPU, 2 GB RAM
-instanceType: s1.medium    # 2 vCPU, 4 GB RAM
-instanceType: s1.large     # 4 vCPU, 8 GB RAM
-instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
-instanceType: s1.3large    # 12 vCPU, 24 GB RAM
-instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
-instanceType: s1.3xlarge   # 24 vCPU, 48 GB RAM
-instanceType: s1.4xlarge   # 32 vCPU, 64 GB RAM
-instanceType: s1.8xlarge   # 64 vCPU, 128 GB RAM
-```
-
-#### Serie U – Universal (Verhältnis 1:4)
+| Serie | Verwendung                                                            |
+| ----- | --------------------------------------------------------------------- |
+| `s1`  | **Standard** — geteilte/burstable CPUs, vCPU:RAM-Verhältnis 1:2       |
+| `u1`  | **Universal** — allgemeine Verwendung, Verhältnis 1:4 (Standard)      |
+| `m1`  | **Memory optimized** — Verhältnis 1:8                                 |
 
 ```yaml
+# Beispiele der Universal-Serie (Verhältnis 1:4)
 instanceType: u1.medium    # 1 vCPU, 4 GB RAM
 instanceType: u1.large     # 2 vCPU, 8 GB RAM
 instanceType: u1.xlarge    # 4 vCPU, 16 GB RAM
@@ -88,9 +119,17 @@ instanceType: u1.4xlarge   # 16 vCPU, 64 GB RAM
 instanceType: u1.8xlarge   # 32 vCPU, 128 GB RAM
 ```
 
-#### Serie M – Memory Optimized (Verhältnis 1:8)
+```yaml
+# Standard-Serie (Verhältnis 1:2)
+instanceType: s1.small     # 1 vCPU, 2 GB RAM
+instanceType: s1.medium    # 2 vCPU, 4 GB RAM
+instanceType: s1.large     # 4 vCPU, 8 GB RAM
+instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
+instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
+```
 
 ```yaml
+# Memory-optimized-Serie (Verhältnis 1:8)
 instanceType: m1.large     # 2 vCPU, 16 GB RAM
 instanceType: m1.xlarge    # 4 vCPU, 32 GB RAM
 instanceType: m1.2xlarge   # 8 vCPU, 64 GB RAM
@@ -98,19 +137,110 @@ instanceType: m1.4xlarge   # 16 vCPU, 128 GB RAM
 instanceType: m1.8xlarge   # 32 vCPU, 256 GB RAM
 ```
 
+:::tip GPU und `instanceType`
+Um eine GPU anzuhängen, wählen Sie eine universelle Serie (`u1`, `s1`…) und deklarieren Sie die GPU über das Feld [`gpus`](#gpu). Der NVIDIA-Treiber erfordert **mindestens 4 GiB RAM**.
+:::
+
 ---
 
-### Unterstützte OS-Profile
+### OS-Profile
 
-Die folgenden Profile stehen zur Konfiguration des Betriebssystems der VM zur Verfügung:
+`instanceProfile` lädt die **KubeVirt-Präferenzen** (Treiber, Maschinenmodell, Kernel), die an das OS angepasst sind. Es definiert **nicht** das Image — dieses wird vom `VMDisk` getragen. Es ist vor allem für Windows ausschlaggebend (virtio-Treiber).
 
-| Profil | Beschreibung |
-|--------|-------------|
-| `ubuntu` | Ubuntu Server (empfohlen) |
-| `centos` | CentOS Stream |
-| `debian` | Debian |
-| `fedora` | Fedora Server |
-| `windows` | Windows Server |
+Verfügbare Werte (Auszug):
+
+| Familie     | Profile                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| Ubuntu      | `ubuntu`                                                                                 |
+| RHEL        | `rhel.7`, `rhel.8`, `rhel.9`, `rhel.10` (+ Varianten `.desktop`, `.arm64`, `.dpdk`, `.realtime`) |
+| CentOS      | `centos.7`, `centos.stream8`, `centos.stream9`, `centos.stream10` (+ `.desktop`, `.dpdk`) |
+| Fedora      | `fedora`, `fedora.arm64`                                                                  |
+| openSUSE    | `opensuse.leap`, `opensuse.tumbleweed`                                                    |
+| SLES        | `sles`                                                                                    |
+| Andere      | `alpine`, `cirros`                                                                        |
+| Windows     | `windows.2k22.virtio`, `windows.2k25.virtio`, `windows.10.virtio`, `windows.11.virtio` (`.virtio`-Varianten **empfohlen**); Varianten ohne virtio ebenfalls verfügbar (`windows.2k22`…) |
+
+:::note
+Es existiert **kein** dediziertes Profil `debian` noch `rocky`/`almalinux`. Verwenden Sie für diese Distributionen `ubuntu` (Debian-Basis) oder lassen Sie `instanceProfile: ""`. Verwenden Sie für Windows immer eine `.virtio`-Variante (z.B.: `windows.2k25.virtio`), um die virtio-Treiber zu laden.
+:::
+
+---
+
+### Festplatten
+
+`disks` ist eine **Liste von Objekten**, die [`VMDisk`](#vmdisk)-Ressourcen über ihren Namen referenzieren. Die erste aufgelistete Festplatte ist in der Regel die bootfähige Festplatte.
+
+| Feld            | Typ      | Beschreibung                                         |
+| --------------- | -------- | ---------------------------------------------------- |
+| `disks[].name`  | `string` | Name des anzuhängenden `VMDisk`                      |
+| `disks[].bus`   | `string` | Bus-Typ (`virtio`, `sata`, `scsi`) — optional        |
+
+```yaml
+spec:
+  disks:
+    - name: vm-system-disk
+    - name: vm-data-disk
+      bus: scsi
+```
+
+:::warning
+Die VM berücksichtigt eine neue Festplatte erst, wenn sie neu gestartet wird (`virtctl restart` oder Umschalten von `runStrategy`).
+:::
+
+---
+
+### GPU
+
+`gpus` hängt eine oder mehrere NVIDIA-GPUs im PCI-Passthrough an.
+
+| Feld           | Typ      | Beschreibung                               |
+| -------------- | -------- | ------------------------------------------ |
+| `gpus[].name`  | `string` | Name der GPU-Ressource (`nvidia.com/...`)  |
+
+```yaml
+spec:
+  instanceType: u1.2xlarge
+  gpus:
+    - name: nvidia.com/AD102GL_L40S
+```
+
+Die auf Hikube verfügbaren Modelle sind in der [GPU-API-Referenz](../gpu/api-reference.md) ausführlich beschrieben. Eine GPU wird einer VM **exklusiv** zugewiesen.
+
+---
+
+### Subnetze
+
+`subnets` bindet die VM an zusätzliche Subnetze eines VPC an.
+
+| Feld              | Typ      | Beschreibung          |
+| ----------------- | -------- | --------------------- |
+| `subnets[].name`  | `string` | Name des Subnetzes    |
+
+```yaml
+spec:
+  subnets:
+    - name: subnet-ab2c3e47
+```
+
+---
+
+### Ressourcen
+
+Standardmäßig wird die CPU-/Speicher-Dimensionierung von `instanceType` getragen. Der Block `resources` ermöglicht es, diese Werte explizit zu **überschreiben** (und eine Socket-Topologie zu definieren).
+
+| Feld                 | Typ             | Beschreibung                         |
+| -------------------- | --------------- | ------------------------------------ |
+| `resources.cpu`      | `int`/`string`  | Anzahl der zugewiesenen CPU-Kerne    |
+| `resources.memory`   | `int`/`string`  | Menge des zugewiesenen Speichers     |
+| `resources.sockets`  | `int`/`string`  | Anzahl der CPU-Sockets (Topologie)   |
+
+```yaml
+spec:
+  resources:
+    cpu: "4"
+    memory: 8Gi
+    sockets: "2"
+```
 
 ---
 
@@ -136,11 +266,11 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
         ssh_authorized_keys:
           - ssh-rsa AAAA...
-
     packages:
       - htop
       - docker.io
-      - curl
+  # Optionaler Seed zum Festlegen der SMBIOS-UUID (Lizenzen, Maschinenidentität)
+  cloudInitSeed: ""
 ```
 
 ---
@@ -157,11 +287,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.2xlarge
   instanceProfile: ubuntu
   disks:
-    - vm-system-disk
+    - name: vm-system-disk
   sshKeys:
     - ssh-rsa AAAA...
 ```
@@ -172,39 +302,36 @@ spec:
 
 ### Übersicht
 
-Die `VMDisk`-API ermöglicht die Verwaltung virtueller Festplatten, die mit VMs verknüpft sind.
-Sie unterstützt **mehrere Image-Quellen**: HTTP, leere Festplatte und **Golden Images**.
+Die `VMDisk`-API verwaltet die an VMs angehängten virtuellen Festplatten. Sie unterstützt mehrere Image-Quellen: **HTTP**, vorgeladenes **Golden Image** oder leere Festplatte.
 
-```yaml
+```yaml title="disk-example.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMDisk
 metadata:
   name: disk-example
 spec:
   source:
-    http:
-      url: https://...
+    image:
+      name: ubuntu-2404
   optical: false
   storage: 30Gi
   storageClass: replicated
 ```
 
----
-
 ### Hauptparameter
 
-| Parameter      | Typ       | Beschreibung             | Standard     | Erforderlich |
-| -------------- | --------- | ------------------------ | ------------ | ------------ |
-| `source`       | `object`  | Quelle des Festplatten-Images | `{}`         | ✅            |
-| `optical`      | `boolean` | Optische Festplatte (ISO) | `false`      | ✅            |
-| `storage`      | `string`  | Festplattengröße         | –            | ✅            |
-| `storageClass` | `string`  | Speicherklasse           | `replicated` | ✅            |
+| Parameter      | Typ             | Beschreibung                                 | Standard     | Erforderlich |
+| -------------- | --------------- | -------------------------------------------- | ------------ | ------------ |
+| `storage`      | `int`/`string`  | Festplattengröße                             | `5Gi`        | ✅           |
+| `storageClass` | `string`        | Speicherklasse                               | `replicated` | ✅           |
+| `source`       | `object`        | Quelle des Festplatten-Images (siehe unten)  | `{}`         | nein         |
+| `optical`      | `boolean`       | Optische Festplatte / ISO (Installer)        | `false`      | nein         |
 
 ---
 
 ## Image-Quellen
 
-### HTTP/HTTPS-Quelle
+### HTTP-/HTTPS-Quelle
 
 ```yaml
 spec:
@@ -213,28 +340,9 @@ spec:
       url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 ```
 
----
-
-### Leere Festplatte
-
-```yaml
-spec:
-  source: {}
-```
-
----
-
 ### Golden Images (vorgeladene Hikube-Images)
 
-**Golden Images** sind Systemimages, die in Hikube gepflegt und vorgeladen werden.
-Sie ermöglichen eine **schnelle**, standardisierte Bereitstellung ohne externe Abhängigkeiten.
-
-:::tip Namenskonvention
-Die Images folgen dem Format `{os}-{version}` (z.B.: `ubuntu-2404`, `rocky-9`).
-Geben Sie immer die Version an, um die Kompatibilität Ihrer Workloads zu gewährleisten.
-:::
-
-#### Verwendung
+Die **Golden Images** sind Systemimages, die in Hikube gepflegt und vorgeladen werden, für eine schnelle Bereitstellung ohne externe Abhängigkeit.
 
 ```yaml
 spec:
@@ -267,20 +375,28 @@ spec:
 | `opensuse-160` | openSUSE Leap 16.0 | Cloud | 2 Gi |
 | `cloudlinux-8` | CloudLinux 8 | Cloud | 8 Gi |
 | `cloudlinux-9` | CloudLinux 9 | Cloud | 9 Gi |
+| `windows-server-2022` | Windows Server 2022 | ISO | 28 Gi |
+| `windows-server-2025` | Windows Server 2025 | ISO | 28 Gi |
 | `proxmox-8` | Proxmox VE 8 | ISO | 2 Gi |
 | `proxmox-9` | Proxmox VE 9 | ISO | 2 Gi |
 | `talos-112` | Talos Linux 1.12 | Cloud | 8 Gi |
 
 :::warning ISO-Images
-Images vom Typ **ISO** (Proxmox) sind Installer, keine sofort einsatzbereiten Cloud-Images.
-Sie erfordern eine manuelle Installation über die VNC-Konsole.
+Images vom Typ **ISO** (Windows, Proxmox) sind Installer und keine sofort einsatzbereiten Cloud-Images. Planen Sie eine Erstinstallation über die VNC-Konsole ein. Für Windows siehe die Anleitung [Eine Windows-VM installieren](how-to/install-windows-vm.md).
 :::
+
+### Leere Festplatte
+
+```yaml
+spec:
+  source: {}
+```
+
+Eine leere Festplatte ist nützlich für zusätzliche Datenvolumes.
 
 ---
 
-### VMDisk-Beispiele
-
-#### Systemfestplatte via Golden Image
+### VMDisk-Beispiel via Golden Image
 
 ```yaml title="ubuntu-golden-disk.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
@@ -300,10 +416,22 @@ spec:
 
 ## Speicherklassen
 
-| Klasse       | Beschreibung        | Replikation |
-| ------------ | ------------------- | ----------- |
-| `local`      | Lokaler Knotenspeicher | ❌           |
-| `replicated` | Replizierter Speicher  | ✅           |
+Hikube exponiert mehrere `storageClass` auf Basis von LINSTOR. Für eine VM wird `replicated` empfohlen.
+
+| Klasse                                 | Replikation | Verschlüsselung | Hinweise                                         |
+| -------------------------------------- | :---------: | :-------------: | ------------------------------------------------ |
+| `local`                                | ❌          | ❌              | Knotenlokaler Speicher (Standard), nicht resilient |
+| `local-encrypted`                      | ❌          | ✅ (LUKS)       | Lokal + verschlüsselt                            |
+| `replicated`                           | ✅          | ❌              | Synchron repliziert — **empfohlen** für VMs      |
+| `replicated-encrypted`                 | ✅          | ✅ (LUKS)       | Repliziert + verschlüsselt                       |
+| `replicated-async`                     | ✅ (async)  | ❌              | Asynchrone Replikation                           |
+| `replicated-async-encrypted`           | ✅ (async)  | ✅ (LUKS)       | Asynchrone Replikation + verschlüsselt           |
+| `replicated-async-windows`             | ✅ (async)  | ❌              | An Windows-Festplatten angepasste Variante       |
+| `replicated-async-windows-encrypted`   | ✅ (async)  | ✅ (LUKS)       | Windows-Variante + verschlüsselt                 |
+
+:::note
+Die `-windows`-Varianten sind für die Festplatten von Windows-VMs optimiert. Die Verschlüsselung (`-encrypted`) stützt sich auf LUKS auf Volume-Ebene.
+:::
 
 ---
 
@@ -312,18 +440,17 @@ spec:
 ### PortList
 
 * Automatische Firewall
-* Explizit autorisierte Ports
-* **Empfohlen für Produktion**
+* Nur die in `externalPorts` aufgelisteten Ports sind erreichbar
+* **Empfohlen für die Produktion**
 
 ### WholeIP
 
-* Alle Ports exponiert
-* Keine Netzwerkfilterung
-* Nur für Entwicklung
+* Eine dedizierte öffentliche IP, alle Ports exponiert
+* Keine Netzwerkfilterung seitens der Plattform
+* Nur für Entwicklung oder kontrollierte Gateways vorbehalten
 
 :::warning Sicherheit
-Mit `WholeIP` ist die VM vollständig im Internet exponiert.
-Eine OS-Firewall ist unerlässlich.
+Mit `WholeIP` ist die VM vollständig im Internet exponiert. Eine OS-Firewall ist unerlässlich.
 :::
 
 ---
@@ -332,18 +459,18 @@ Eine OS-Firewall ist unerlässlich.
 
 ### Sicherheit
 
-* Nur SSH-Schlüssel
-* Aktive OS-Firewall
+* Authentifizierung ausschließlich über SSH-Schlüssel
+* Aktive OS-Firewall, `PortList` statt `WholeIP`
 
 ### Speicher
 
-* `replicated` in der Produktion
-* Getrennte Festplatten für System / Daten
+* `replicated` (oder verschlüsselte/Windows-Varianten) in der Produktion
+* System- und Datenfestplatten trennen
 
 ### Leistung
 
-* Instanztyp an den Workload anpassen
-* Tatsächliche Nutzung überwachen
+* `instanceType` an den Workload anpassen oder über `resources` überschreiben
+* Für GPUs ≥ 4 GiB RAM und ein angepasstes CPU/RAM-Verhältnis vorsehen
 
 :::tip Empfohlene Architektur
 Verwenden Sie in der Produktion mindestens **2 Festplatten** (System + Daten) mit repliziertem Speicher.

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/compute/faq.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/compute/faq.md
@@ -68,7 +68,7 @@ kind: VMDisk
 metadata:
   name: data-volume
 spec:
-  size: 100Gi
+  storage: 100Gi
   storageClass: replicated
 ```
 
@@ -81,7 +81,7 @@ spec:
   instanceType: u1.large
   instanceProfile: ubuntu
   disks:
-    - data-volume
+    - name: data-volume
 ```
 
 ---
@@ -149,7 +149,7 @@ Cloud-init wird beim ersten Start der VM ausgeführt und ermöglicht die Install
 
 | Parameter | Rolle | Beispiele |
 |-----------|------|----------|
-| `instanceProfile` | Lädt die **Treiber und Kernel**, die an das OS angepasst sind | `ubuntu`, `centos`, `windows.2k25.virtio` |
+| `instanceProfile` | Lädt die **Treiber und Kernel**, die an das OS angepasst sind | `ubuntu`, `centos.stream9`, `windows.2k25.virtio` |
 | `instanceType` | Definiert die **Größe** der VM (CPU/RAM) | `s1.small`, `u1.large`, `m1.2xlarge` |
 
 `instanceProfile` bestimmt nicht das OS-Image — dieses wird in der **VMDisk**-Ressource über `source.image.name` definiert. Das Profil dient dazu, optimierte Treiber und Kernel für das Betriebssystem zu laden. Dies ist hauptsächlich für **Windows** nützlich (virtio-Treiber). `instanceType` dimensioniert die der VM zugewiesenen CPU- und Speicher-Ressourcen.

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
@@ -67,8 +67,8 @@ spec:
   externalPorts:
     - 22
   disks:
-    - vm-system-disk
-    - vm-data-disk
+    - name: vm-system-disk
+    - name: vm-data-disk
   sshKeys:
     - ssh-ed25519 AAAA... user@host
 ```

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Schnellstart
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # Erstellen Sie Ihre erste Virtuelle Maschine
 
 Diese Anleitung begleitet Sie bei der Erstellung Ihrer ersten virtuellen Maschine auf Hikube in **5 Minuten**!
@@ -96,14 +98,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.xlarge
   instanceProfile: "ubuntu"
   disks:
-    - name: disk-example #Den Namen Ihrer Festplatte angeben
-  resources:
-    cpu: ""
-    memory: ""
+    - name: disk-example # Name des anzuhängenden VMDisk
   sshKeys:
     - ihr-oeffentlicher-schluessel-hier
   cloudInit: |
@@ -235,10 +234,10 @@ Das Löschen von VMs und Festplatten ist **unwiderruflich**. Stellen Sie sicher,
 
 <div style={{display: 'flex', gap: '20px', flexWrap: 'wrap'}}>
 
-**📚 Erweiterte Konfiguration**
+**📚 Erweiterte Konfiguration**  
 → [Vollständige API-Referenz](./api-reference.md)
 
-**📖 Technische Architektur**
+**📖 Technische Architektur**  
 → [Funktionsweise verstehen](./overview.md)
 
 </div>
@@ -250,3 +249,10 @@ Das Löschen von VMs und Festplatten ist **unwiderruflich**. Stellen Sie sicher,
 - Ihre **Daten sind immer sicher** dank der Replikation über 3 Rechenzentren
 - Ihre VM kann bei einem Knotenausfall **automatisch verlagert** werden
 - Die **vollständige Isolation** gewährleistet die Sicherheit zwischen Tenants
+
+<NavigationFooter
+  nextSteps={[
+    {label: "FAQ", href: "../faq"},
+    {label: "API-Referenz", href: "../api-reference"},
+  ]}
+/>

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
@@ -107,7 +107,7 @@ Dieses Problem betrifft alle Distributionen, die `systemd-resolved` verwenden (U
    ```yaml title="vm.yaml"
    spec:
      disks:
-       - data-volume  # Muss mit metadata.name des VMDisk übereinstimmen
+       - name: data-volume  # Muss mit metadata.name des VMDisk übereinstimmen
    ```
 
 2. Überprüfen Sie den Status des VMDisk:
@@ -116,7 +116,7 @@ Dieses Problem betrifft alle Distributionen, die `systemd-resolved` verwenden (U
    kubectl describe vmdisk data-volume
    ```
 
-3. Die auf Hikube verfügbaren storageClasses sind: `local`, `replicated` und `replicated-async`. Für eine VM (isolierte Instanz) wird `replicated` empfohlen.
+3. Die auf Hikube verfügbaren storageClasses sind: `local`, `local-encrypted`, `replicated`, `replicated-encrypted`, `replicated-async`, `replicated-async-encrypted`, `replicated-async-windows` und `replicated-async-windows-encrypted`. Für eine VM (isolierte Instanz) wird `replicated` empfohlen.
 
 ---
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
@@ -5,74 +5,85 @@ title: API-Referenz
 
 # API-Referenz - GPU
 
-Diese Referenz beschreibt die APIs zur Nutzung von GPUs auf Hikube, sowohl mit virtuellen Maschinen als auch mit Kubernetes-Clustern.
+Diese Referenz beschreibt die Nutzung von GPUs auf Hikube, sowohl mit virtuellen Maschinen (`VMInstance`) als auch mit verwalteten Kubernetes-Clustern (`Kubernetes`).
+
+---
+
+## 🎮 Verfügbare GPUs
+
+GPUs werden über ihren **Ressourcennamen** (`nvidia.com/<modell>`) angehängt. Die auf Hikube verfügbaren Modelle:
+
+| GPU | Ressourcenname | Architektur | Speicher | Typischer Einsatz |
+|-----|------------------|--------------|---------|---------------|
+| **L40S** | `nvidia.com/AD102GL_L40S` | Ada Lovelace | 48 GB GDDR6 | Inferenz, Entwicklung, Rendering |
+| **A100 PCIe 80 GB** | `nvidia.com/GA100_A100_PCIE_80GB` | Ampere | 80 GB HBM2e | ML-Training |
+| **A100 SXM4 80 GB** | `nvidia.com/GA100_A100_SXM4_80GB` | Ampere | 80 GB HBM2e | ML-Training (Multi-GPU NVLink) |
+| **RTX PRO 6000 Blackwell** | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` | Blackwell | 96 GB GDDR7 | LLM, intensives Rechnen |
+
+:::note Verfügbarkeit
+Die verfügbare GPU-Hardware variiert je nach Zone. Überprüfen Sie die zuteilbaren Ressourcen auf der Plattformseite, bevor Sie einen Workload planen. Der NVIDIA-Treiber benötigt **mindestens 4 GiB RAM** auf der VM oder dem Worker.
+:::
 
 ---
 
 ## 🖥️ GPU mit Virtuellen Maschinen
 
-### **VirtualMachine-API**
+Auf einer VM wird der GPU im **PCI Passthrough** (exklusive Zuweisung) über das Feld `gpus` einer [`VMInstance`](../compute/api-reference.md)-Ressource angehängt. Die Festplatte wird separat durch eine [`VMDisk`](../compute/api-reference.md#vmdisk)-Ressource definiert.
 
-```yaml
+```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
-#### **GPU-Parameter für VM**
+:::warning Häufige Stolperfallen
+- Die Ressource heißt **`VMInstance`** (nicht `VirtualMachine`).
+- Der Zustand wird über **`runStrategy: Always`** gesteuert (nicht `running: true`).
+- Die Festplatte ist **kein** integriertes `systemDisk`-Feld: Erstellen Sie eine `VMDisk`-Ressource und referenzieren Sie sie in `disks` (Liste von `{name}`-Objekten).
+:::
+
+### GPU-Parameter für VM
 
 | **Parameter** | **Typ** | **Beschreibung** | **Erforderlich** |
 |---------------|----------|-----------------|------------|
-| `gpus` | `[]GPU` | Liste der anzuhängenden GPUs | ✅ |
-| `gpus[].name` | `string` | NVIDIA GPU-Typ | ✅ |
+| `gpus` | `[]object` | Liste der anzuhängenden GPUs | nein |
+| `gpus[].name` | `string` | Name der GPU-Ressource (`nvidia.com/...`) | ja (wenn `gpus` definiert) |
 
-#### **Verfügbare GPU-Typen**
+### Vollständiges VM GPU-Beispiel
 
-```yaml
-# GPU für Inferenz und Entwicklung
-gpus:
-  - name: "nvidia.com/AD102GL_L40S"
-
-# GPU für ML-Training
-gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"
-
-# GPU für LLM und Exascale-Rechnen
-gpus:
-  - name: "nvidia.com/H100_94GB"
-```
-
-#### **Hardware-Spezifikationen**
-
-| **GPU** | **Architektur** | **Speicher** | **Leistung** |
-|---------|------------------|-------------|-----------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) |
-
-#### **Vollständiges VM GPU-Beispiel**
-
-```yaml
+```yaml title="ai-workstation.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMDisk
+metadata:
+  name: ai-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMInstance
 metadata:
   name: ai-workstation
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.2xlarge  # 8 vCPU, 32 GB RAM
   gpus:
     - name: "nvidia.com/GA100_A100_PCIE_80GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+  disks:
+    - name: ai-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -83,36 +94,45 @@ spec:
     users:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
-
     packages:
       - python3-pip
       - build-essential
-
     runcmd:
-      # NVIDIA-Treiber
-      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-      - dpkg -i cuda-keyring_1.0-1_all.deb
+      # NVIDIA-Treiber + CUDA (genaue Version siehe dediziertes Handbuch)
+      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+      - dpkg -i cuda-keyring_1.1-1_all.deb
       - apt-get update
-      - apt-get install -y cuda-toolkit nvidia-driver-535
-
+      - apt-get install -y cuda-toolkit nvidia-driver-570
       # PyTorch mit CUDA
-      - pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+      - pip3 install torch torchvision
+```
+
+### Multi-GPU auf VM
+
+```yaml
+spec:
+  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
+  gpus:
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
 ---
 
 ## ☸️ GPU mit Kubernetes
 
-### **Kubernetes-API mit GPU-Workern**
+Auf einem verwalteten Kubernetes-Cluster werden die GPUs an die **Node Groups** angehängt, und der Addon **`gpuOperator`** muss aktiviert sein, um die GPUs den Pods bereitzustellen.
 
-```yaml
+```yaml title="cluster-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: cluster-gpu
 spec:
   controlPlane:
-    replicas: 1
+    replicas: 2
 
   nodeGroups:
     gpu-workers:
@@ -122,16 +142,26 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Erforderlich: installiert die NVIDIA-Treiber und das Device Plugin
+    gpuOperator:
+      enabled: true
 ```
 
-#### **GPU-Parameter für NodeGroups**
+:::warning Addon `gpuOperator` erforderlich
+Ohne `gpuOperator: enabled: true` werden die GPUs der Worker nicht den Pods bereitgestellt (`nvidia.com/gpu` bleibt bei 0).
+:::
+
+### GPU-Parameter für NodeGroups
 
 | **Parameter** | **Typ** | **Beschreibung** | **Erforderlich** |
 |---------------|----------|-----------------|------------|
-| `nodeGroups.<name>.gpus` | `[]GPU` | GPUs für die Worker | ❌ |
-| `gpus[].name` | `string` | NVIDIA GPU-Typ | ✅ |
+| `nodeGroups.<name>.gpus` | `[]object` | An die Worker der Gruppe angehängte GPUs | nein |
+| `gpus[].name` | `string` | Name der GPU-Ressource (`nvidia.com/...`) | ja (wenn `gpus` definiert) |
+| `addons.gpuOperator.enabled` | `boolean` | Aktiviert den NVIDIA GPU Operator | ja (um die GPUs zu nutzen) |
 
-#### **Multi-GPU-Konfiguration**
+### Multi-GPU-Konfiguration pro Worker
 
 ```yaml
 nodeGroups:
@@ -140,15 +170,17 @@ nodeGroups:
     maxReplicas: 2
     instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
     gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
-#### **Verwendung in Pods**
+### Verwendung in Pods
 
-```yaml
+Sobald der `gpuOperator` aktiv ist, reservieren die Pods die GPUs über die Ressource `nvidia.com/gpu`:
+
+```yaml title="ml-training.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -156,193 +188,61 @@ metadata:
 spec:
   containers:
   - name: trainer
-    image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+    image: pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
     resources:
       limits:
         nvidia.com/gpu: 1
       requests:
         nvidia.com/gpu: 1
-    command:
-      - python
-      - train.py
-```
-
-#### **Multi-GPU-Job**
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: distributed-training
-spec:
-  template:
-    spec:
-      containers:
-      - name: trainer
-        image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
-        resources:
-          limits:
-            nvidia.com/gpu: 4
-          requests:
-            nvidia.com/gpu: 4
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0,1,2,3"
-      restartPolicy: Never
+    command: ["python", "train.py"]
 ```
 
 ---
 
-## 📋 Vergleich der Ansätze
-
-### **VM GPU vs Kubernetes GPU**
+## 📋 VM GPU vs Kubernetes GPU
 
 | **Aspekt** | **VM GPU** | **Kubernetes GPU** |
 |------------|------------|-------------------|
-| **Zuweisung** | 1 GPU = 1 VM (exklusiv) | 1+ GPU pro Worker (teilbar) |
-| **Isolation** | Vollständig auf VM-Ebene | Namespace/Pod |
-| **Skalierung** | Vertikal (mehr GPUs) | Horizontal + Vertikal |
-| **Verwaltung** | Manuell via YAML | Orchestriert durch K8s |
+| **Zuweisung** | 1 GPU = 1 VM (exklusiver Passthrough) | 1+ GPU pro Worker |
+| **Isolation** | Vollständig auf VM-Ebene | Namespace / Pod |
+| **Skalierung** | Vertikal (mehr GPUs) | Horizontal + Vertikal (Autoscaling) |
+| **Verwaltung** | Manuell via `VMInstance` | Orchestriert durch Kubernetes |
 | **Teilung** | Nein | Ja (zwischen Pods) |
 | **Overhead** | Minimal | Orchestrierungs-Overhead |
 
-### **Wann welchen Ansatz verwenden**
+**VM GPU**: nicht-containerisierte Anwendungen, direkter GPU-Zugang, Entwicklung/Prototyping, Rendering/CAD.
 
-#### **VM GPU empfohlen für:**
-
-- Nicht-containerisierte Legacy-Anwendungen
-- Bedarf an direktem und vollständigem GPU-Zugang
-- Entwicklung und Prototyping
-- Monolithische Workloads
-- Grafische Anwendungen (Rendering, CAD)
-
-#### **Kubernetes GPU empfohlen für:**
-
-- Containerisierte Anwendungen
-- Workloads, die automatische Skalierung erfordern
-- Parallele und verteilte Jobs
-- GPU-Ressourcenteilung
-- Komplexe ML/AI-Pipelines
+**Kubernetes GPU**: containerisierte Workloads, Autoscaling, parallele/verteilte Jobs, ML/AI-Pipelines.
 
 ---
 
-## 🔧 Erweiterte Konfiguration
+## ✅ Überprüfung
 
-### **Multi-GPU auf VM**
-
-```yaml
-apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
-metadata:
-  name: multi-gpu-vm
-spec:
-  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
-  gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-```
-
-### **Spezialisierte GPU-NodeGroup**
-
-```yaml
-nodeGroups:
-  gpu-inference:
-    minReplicas: 2
-    maxReplicas: 10
-    instanceType: "u1.large"
-    gpus:
-      - name: "nvidia.com/AD102GL_L40S"
-
-  gpu-training:
-    minReplicas: 1
-    maxReplicas: 3
-    instanceType: "u1.4xlarge"
-    gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-```
-
-### **Pod mit spezifischem GPU**
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: specific-gpu-pod
-spec:
-  nodeSelector:
-    gpu-type: "L40S"
-  containers:
-  - name: app
-    image: nvidia/cuda:12.0-runtime-ubuntu20.04
-    resources:
-      limits:
-        nvidia.com/gpu: 1
-```
-
----
-
-## ✅ Überprüfung und Monitoring
-
-### **VM GPU-Überprüfung**
+### VM GPU
 
 ```bash
-# Auf die VM zugreifen
 virtctl ssh ubuntu@vm-gpu
-
-# GPUs überprüfen
 nvidia-smi
-
-# CUDA-Test
 nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
 ```
 
-### **Kubernetes GPU-Überprüfung**
+### Kubernetes GPU
 
 ```bash
-# GPU-Ressourcen auf den Nodes anzeigen
-kubectl describe nodes
-
-# GPU-Zuweisung überprüfen
+# Auf den Nodes bereitgestellte GPUs (erfordert aktiven gpuOperator)
 kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.'nvidia\.com/gpu'
 
-# GPU-Nutzung überwachen
-kubectl top nodes
-```
-
-### **GPU-Monitoring in einem Pod**
-
-```bash
-# In einen Pod mit GPU einsteigen
+# Aus einem Pod heraus überprüfen
 kubectl exec -it <pod-name> -- nvidia-smi
-
-# GPU-Metriken anzeigen
-kubectl exec -it <pod-name> -- nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv -l 5
 ```
 
 ---
 
 ## 💡 Best Practices
 
-### **Für VM GPU:**
-
-- Verwenden Sie die `replicated` Storage Class für die Produktion
-- Dimensionieren Sie CPU/RAM entsprechend dem GPU (Verhältnis 8-16 vCPU pro GPU)
-- Installieren Sie NVIDIA-Treiber über cloud-init
-- Stoppen Sie VMs bei Nichtbenutzung, um Kosten zu optimieren
-
-### **Für Kubernetes GPU:**
-
-- Konfigurieren Sie angemessene Resource Limits
-- Verwenden Sie nodeSelector oder nodeAffinity, um spezifische GPUs anzuvisieren
-- Implementieren Sie PodDisruptionBudgets für kritische Workloads
-- Überwachen Sie die GPU-Nutzung mit benutzerdefinierten Metriken
-
-### **Allgemein:**
-
-- L40S für Inferenz/Entwicklung
-- A100 für Standard-ML-Training
-- H100 für LLM und Exascale-Rechnen
-- Testen Sie mit L40S, bevor Sie auf teurere GPUs umsteigen
+- **L40S** für Inferenz und Entwicklung, **A100** für ML-Training, **RTX PRO 6000 (Blackwell)** für die anspruchsvollsten Workloads.
+- Testen Sie mit einem L40S, bevor Sie die teureren GPUs reservieren.
+- Dimensionieren Sie CPU/RAM entsprechend dem GPU (≈ 8–16 vCPU pro GPU) und planen Sie ≥ 4 GiB RAM ein.
+- Auf VM: installieren Sie die NVIDIA-Treiber über cloud-init (siehe [CUDA-Treiber installieren](../compute/how-to/install-cuda-drivers.md)).
+- Auf Kubernetes: aktivieren Sie immer den Addon `gpuOperator`.
+- Verwenden Sie die `storageClass` `replicated` in der Produktion.

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
@@ -15,7 +15,7 @@ graph TB
         subgraph "Physische GPUs"
             G1[NVIDIA L40S]
             G2[NVIDIA A100]
-            G3[NVIDIA H100]
+            G3[NVIDIA RTX PRO 6000<br/>Blackwell]
         end
 
         subgraph "VM-Zuweisung"
@@ -58,19 +58,20 @@ graph TB
 
 ## Verfügbare GPU-Typen
 
-| GPU | Architektur | Speicher | Leistung (INT8) | Anwendungsfall |
-|-----|-------------|---------|-------------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS | Inferenz, Entwicklung, Prototyping |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS | ML-Training, Fine-Tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS | LLM, Exascale-Rechnen, verteiltes Training |
+| GPU | Architektur | Speicher | Anwendungsfall |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenz, Entwicklung, Prototyping |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML-Training, Fine-Tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensives Rechnen, verteiltes Training |
 
 ### GPU-Bezeichner in den Manifesten
 
-| GPU | Wert `gpus[].name` / `nvidia.com/` |
-|-----|---------------------------------------|
+| GPU | Wert `gpus[].name` |
+|-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ---
 
@@ -93,8 +94,8 @@ Planen Sie **8 bis 16 vCPU pro GPU**. Für einen einzelnen GPU ist ein `u1.2xlar
 
 GPUs werden den Pods über das **NVIDIA Device Plugin** exponiert:
 
-- Der GPU Operator muss auf dem Cluster aktiviert sein (`plugins.gpu-operator.enabled: true`)
-- Pods fordern einen GPU über `resources.limits` an (z.B.: `nvidia.com/AD102GL_L40S: 1`)
+- Der GPU Operator muss auf dem Cluster aktiviert sein (`addons.gpuOperator.enabled: true`)
+- Pods fordern einen GPU über `resources.limits` an (`nvidia.com/gpu: 1`)
 - Der Kubernetes-Scheduler platziert den Pod auf einem Knoten mit dem angeforderten GPU
 - GPU-Knoten werden in den **Node Groups** mit dem Feld `gpus[]` konfiguriert
 
@@ -108,7 +109,7 @@ graph LR
 
     subgraph "Pod"
         C[Container]
-        RL[resources.limits:<br/>nvidia.com/AD102GL_L40S: 1]
+        RL[resources.limits:<br/>nvidia.com/gpu: 1]
     end
 
     GPU --> DP
@@ -136,8 +137,8 @@ graph LR
 |-----------|--------|
 | GPU pro VM | Mehrere (je nach Verfügbarkeit) |
 | GPU pro Kubernetes-Pod | Mehrere (über `resources.limits`) |
-| GPU-Typen | L40S, A100, H100 |
-| Max. GPU-Speicher | 80 GB (A100/H100) |
+| GPU-Typen | L40S, A100 (PCIe/SXM4), RTX PRO 6000 Blackwell |
+| Max. GPU-Speicher | 96 GB (RTX PRO 6000 Blackwell) |
 
 ---
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/faq.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/faq.md
@@ -7,21 +7,22 @@ title: FAQ
 
 ### Welche GPU-Modelle sind verfügbar?
 
-Hikube bietet drei NVIDIA GPU-Familien:
+Hikube bietet mehrere NVIDIA-GPUs:
 
 | GPU | Architektur | Speicher | Anwendungsfall |
 |-----|-------------|---------|-------------|
 | **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenz, Grafik-Rendering |
-| **A100** | Ampere | 80 GB HBM2e | ML-Training, wissenschaftliches Rechnen |
-| **H100** | Hopper | 80 GB HBM3 | LLM, Exascale-Rechnen |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML-Training, wissenschaftliches Rechnen |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensives Rechnen |
 
 Die in den Manifesten zu verwendenden Bezeichner:
 
 ```yaml
 gpus:
-  - name: "nvidia.com/AD102GL_L40S"       # L40S
-  - name: "nvidia.com/GA100_A100_PCIE_80GB" # A100
-  - name: "nvidia.com/H100_94GB"           # H100
+  - name: "nvidia.com/AD102GL_L40S"                                  # L40S
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"                          # A100 PCIe
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"                          # A100 SXM4
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION" # RTX PRO 6000 Blackwell
 ```
 
 ---

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
@@ -41,7 +41,16 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Erforderlich: installiert die NVIDIA-Treiber und das Device Plugin
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` erforderlich
+Das Anhängen der GPUs an die Node Groups reicht nicht aus: ohne `addons.gpuOperator.enabled: true` werden die NVIDIA-Treiber und das Device Plugin nicht im Tenant-Cluster installiert, und `nvidia.com/gpu` bleibt bei 0 auf den Nodes.
+:::
 
 :::tip
 Trennen Sie Ihre CPU- und GPU-Workloads in separate Node Groups. Dies ermöglicht eine unabhängige Skalierung und eine bessere Kostenkontrolle.
@@ -170,6 +179,10 @@ spec:
       gpus:
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
+
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 Um eine spezifische Node Group in Ihren Deployments anzuvisieren, verwenden Sie `nodeSelector`:
@@ -202,7 +215,7 @@ spec:
 ```
 
 :::note
-Die für Kubernetes verfügbaren GPUs sind dieselben wie für VMs: **L40S** (Inferenz/Entwicklung), **A100** (ML-Training) und **H100** (LLM/Exascale). Konsultieren Sie die [GPU API-Referenz](../api-reference.md) für die vollständigen Spezifikationen.
+Die für Kubernetes verfügbaren GPUs sind dieselben wie für VMs: **L40S** (Inferenz/Entwicklung), **A100 PCIe/SXM4** (ML-Training) und **RTX PRO 6000 Blackwell** (LLM/intensives Rechnen). Konsultieren Sie die [GPU API-Referenz](../api-reference.md) für die genauen Ressourcennamen und die Spezifikationen.
 :::
 
 ## Überprüfung

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
@@ -16,16 +16,16 @@ Hikube ermöglicht es, einen oder mehrere NVIDIA-GPUs direkt an eine virtuelle M
 
 ### 1. GPU-Typ auswählen
 
-Hikube bietet drei NVIDIA GPU-Familien für verschiedene Anwendungsfälle:
+Hikube bietet mehrere NVIDIA-GPUs für verschiedene Anwendungsfälle:
 
-| GPU | Architektur | Speicher | Leistung | Anwendungsfall |
-|-----|-------------|---------|-------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) | Inferenz, Entwicklung, Prototyping |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) | ML-Training, Fine-Tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) | LLM, Exascale-Rechnen, verteiltes Training |
+| GPU | Architektur | Speicher | Anwendungsfall |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenz, Entwicklung, Prototyping |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML-Training, Fine-Tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensives Rechnen, verteiltes Training |
 
 :::tip Welchen GPU wählen?
-Beginnen Sie mit einem **L40S** für Entwicklung und Prototyping. Wechseln Sie zu einem **A100** für Standard-ML-Modelltraining und reservieren Sie den **H100** für anspruchsvolle Workloads wie LLM-Training oder Hochleistungsrechnen.
+Beginnen Sie mit einem **L40S** für Entwicklung und Prototyping. Wechseln Sie zu einem **A100** für Standard-ML-Modelltraining und reservieren Sie den **RTX PRO 6000 (Blackwell)** für die anspruchsvollsten Workloads wie LLM-Training oder Hochleistungsrechnen.
 :::
 
 Die GPU-Bezeichner für Ihre Manifeste sind:
@@ -33,14 +33,26 @@ Die GPU-Bezeichner für Ihre Manifeste sind:
 | GPU | Wert `gpus[].name` |
 |-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ### 2. VM-Manifest mit GPU erstellen
 
 Erstellen Sie ein Manifest, das den gewünschten GPU im Abschnitt `spec.gpus` deklariert:
 
 ```yaml title="gpu-vm.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: gpu-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 100Gi
+  storageClass: replicated
+---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -51,9 +63,8 @@ spec:
   instanceType: u1.2xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 100Gi
-    storageClass: replicated
+  disks:
+    - name: gpu-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -132,6 +143,17 @@ Für intensive Workloads (verteiltes Training, Inferenz im großen Maßstab) kö
 
 ```yaml title="multi-gpu-vm.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: multi-gpu-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
   name: multi-gpu-workstation
@@ -140,13 +162,12 @@ spec:
   instanceProfile: ubuntu
   instanceType: u1.8xlarge
   gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+  disks:
+    - name: multi-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/overview.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/overview.md
@@ -3,6 +3,8 @@ sidebar_position: 1
 title: GPU-Übersicht
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # GPUs auf Hikube
 
 Hikube bietet Zugang zu **NVIDIA**-Beschleunigern über GPU Passthrough, was die Ausführung von Workloads ermöglicht, die Hardware-Beschleunigung benötigen. GPUs sind für zwei Arten von Workloads verfügbar: Virtuelle Maschinen und Kubernetes-Pods.
@@ -37,28 +39,28 @@ GPUs können Kubernetes-Workern zugewiesen und dann über Resource Requests/Limi
 
 ## 🖥️ Verfügbare Hardware
 
-Hikube bietet drei Typen von NVIDIA-GPUs:
+Hikube bietet mehrere NVIDIA-GPUs:
 
 ### **NVIDIA L40S**
 
 - **Architektur**: Ada Lovelace
 - **Speicher**: 48 GB GDDR6 mit ECC
-- **Leistung**: 362 TOPS (INT8), 91.6 TFLOPs (FP32)
+- **Ressourcenname**: `nvidia.com/AD102GL_L40S`
 - **Typischer Einsatz**: Generative KI, Inferenz, Echtzeit-Rendering
 
-### **NVIDIA A100**
+### **NVIDIA A100 80 GB (PCIe / SXM4)**
 
 - **Architektur**: Ampere
 - **Speicher**: 80 GB HBM2e mit ECC
-- **Leistung**: 312 TOPS (INT8), 624 TFLOPs (Tensor)
-- **Typischer Einsatz**: ML-Training, Hochleistungsrechnen
+- **Ressourcennamen**: `nvidia.com/GA100_A100_PCIE_80GB`, `nvidia.com/GA100_A100_SXM4_80GB`
+- **Typischer Einsatz**: ML-Training, Hochleistungsrechnen (die SXM4-Variante unterstützt NVLink für Multi-GPU)
 
-### **NVIDIA H100**
+### **NVIDIA RTX PRO 6000 Blackwell**
 
-- **Architektur**: Hopper
-- **Speicher**: 80 GB HBM3 mit ECC
-- **Leistung**: 1979 TOPS (INT8), 989 TFLOPs (Tensor)
-- **Typischer Einsatz**: LLM, Transformers, Exascale-Rechnen
+- **Architektur**: Blackwell (Server Edition)
+- **Speicher**: 96 GB GDDR7 mit ECC
+- **Ressourcenname**: `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`
+- **Typischer Einsatz**: LLM, Transformers, intensives Rechnen
 
 ---
 
@@ -72,17 +74,17 @@ flowchart TD
         subgraph NODE["Physischer Knoten"]
             GPU1["🎮 GPU L40S"]
             GPU2["🎮 GPU A100"]
-            GPU3["🎮 GPU H100"]
+            GPU3["🎮 GPU RTX PRO 6000"]
         end
-
+        
         subgraph VM1["VM Instance"]
             APP1["GPU-Anwendung"]
         end
     end
-
+    
     GPU1 --> VM1
     VM1 --> APP1
-
+    
     style GPU1 fill:#90EE90
     style VM1 fill:#FFE4B5
     style APP1 fill:#ADD8E6
@@ -98,23 +100,23 @@ flowchart TD
             GPU2["🎮 GPU A100"]
             KUBELET["kubelet"]
         end
-
+        
         subgraph POD1["Pod"]
             CONTAINER1["GPU-Container"]
         end
-
+        
         subgraph POD2["Pod"]
             CONTAINER2["GPU-Container"]
         end
     end
-
+    
     GPU1 --> KUBELET
     GPU2 --> KUBELET
     KUBELET --> POD1
     KUBELET --> POD2
     POD1 --> CONTAINER1
     POD2 --> CONTAINER2
-
+    
     style GPU1 fill:#90EE90
     style GPU2 fill:#90EE90
     style POD1 fill:#FFE4B5
@@ -129,11 +131,14 @@ flowchart TD
 
 ```yaml
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 spec:
+  runStrategy: Always
   instanceType: "u1.xlarge"
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
 ### **GPU auf Kubernetes Worker**
@@ -147,6 +152,9 @@ spec:
       instanceType: "u1.xlarge"
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 ### **GPU in Kubernetes-Pod**
@@ -189,3 +197,13 @@ spec:
 
 - [GPU-Cluster](../kubernetes/overview.md) → Worker mit GPU
   - [Erweiterte Konfiguration](../kubernetes/api-reference.md) → GPU-NodeGroups
+
+<NavigationFooter
+  nextSteps={[
+    {label: "Konzepte", href: "../concepts"},
+    {label: "Schnellstart", href: "../quick-start"},
+  ]}
+  seeAlso={[
+    {label: "Rechenressourcen", href: "../../compute/"},
+  ]}
+/>

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Schnellstart
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # GPUs auf Hikube nutzen
 
 Diese Anleitung stellt die beiden Methoden zur GPU-Nutzung vor: mit virtuellen Maschinen und mit Kubernetes-Clustern.
@@ -40,18 +42,17 @@ spec:
 
 ```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu-example
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge  # 4 vCPU, 16 GB RAM
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 50Gi
-    storageClass: replicated
+  disks:
+    - name: ubuntu-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -64,13 +65,13 @@ spec:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
         shell: /bin/bash
-
+    
     package_update: true
     packages:
       - curl
       - wget
       - build-essential
-
+    
     runcmd:
       # NVIDIA-Treiber installieren
       - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
@@ -87,7 +88,7 @@ kubectl apply -f vm-disk.yaml
 kubectl apply -f vm-gpu.yaml
 
 # Status überprüfen
-kubectl get virtualmachine vm-gpu-example
+kubectl get vminstance vm-gpu-example
 ```
 
 ### **Schritt 4: Zugreifen und testen**
@@ -114,7 +115,7 @@ metadata:
 spec:
   controlPlane:
     replicas: 1
-
+  
   nodeGroups:
     # GPU-Worker
     gpu-nodes:
@@ -124,7 +125,7 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
-
+    
     # Standard-Worker (optional)
     standard-nodes:
       minReplicas: 1
@@ -133,7 +134,17 @@ spec:
       ephemeralStorage: 50Gi
 
   storageClass: "replicated"
+
+  addons:
+    # Unverzichtbar: installiert die NVIDIA-Treiber und das Device Plugin,
+    # die nvidia.com/gpu den Pods des Tenant-Clusters bereitstellen
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` erforderlich
+Ohne aktivierten Addon `gpuOperator` werden die an die Worker angehängten GPUs **nicht** den Pods bereitgestellt (`nvidia.com/gpu` bleibt bei 0). Er installiert die NVIDIA-Treiber und das Device Plugin im Tenant-Cluster.
+:::
 
 ### **Schritt 2: Cluster bereitstellen**
 
@@ -209,13 +220,15 @@ kubectl exec -it gpu-test -- nvidia-smi
 gpus:
   - name: "nvidia.com/AD102GL_L40S"  # 48 GB GDDR6
 
-# Für ML-Training
+# Für ML-Training (A100, zwei Varianten je nach Hardware)
 gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e (PCIe)
+  # oder
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"  # 80 GB HBM2e (SXM4)
 
 # Für LLM/Exascale-Rechnen
 gpus:
-  - name: "nvidia.com/H100_94GB"  # 80 GB HBM3
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"  # 96 GB GDDR7
 ```
 
 ---
@@ -283,5 +296,15 @@ Diese Aktionen löschen die GPU-Ressourcen und alle zugehörigen Daten. Diese Op
 
 - **VM GPU**: Ideal für Prototyping und Legacy-Anwendungen
 - **Kubernetes GPU**: Empfohlen für skalierbare Produktions-Workloads
-- Beginnen Sie mit **L40S** zum Testen, bevor Sie A100/H100 verwenden
+- Beginnen Sie mit **L40S** zum Testen, bevor Sie A100 oder RTX PRO 6000 (Blackwell) verwenden
 - Verwenden Sie die `replicated` Storage Class für die Produktion
+
+<NavigationFooter
+  nextSteps={[
+    {label: "FAQ", href: "../faq"},
+    {label: "API-Referenz", href: "../api-reference"},
+  ]}
+  seeAlso={[
+    {label: "Rechenressourcen", href: "../../compute/"},
+  ]}
+/>

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
@@ -3,205 +3,294 @@ sidebar_position: 6
 title: API-Referenz
 ---
 
-# Vollständige Beispiele
+# API-Referenz – Kubernetes
 
-## **Produktions-Cluster**
+Diese Referenz beschreibt die **`Kubernetes`**-API von Hikube (`apps.cozystack.io/v1alpha1`), die verwaltete Kubernetes-Cluster bereitstellt (Control Plane Kamaji + KubeVirt-Workers). Die folgenden Felder entsprechen dem tatsächlich von der Plattform bereitgestellten Schema.
+
+```yaml title="cluster.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kubernetes
+metadata:
+  name: my-cluster
+spec:
+  version: v1.35
+  storageClass: replicated
+  controlPlane:
+    replicas: 2
+  nodeGroups:
+    md0:
+      minReplicas: 1
+      maxReplicas: 5
+      instanceType: u1.medium
+      ephemeralStorage: 20Gi
+      roles:
+        - ingress-nginx
+  addons:
+    ingressNginx:
+      enabled: true
+```
+
+---
+
+## Spezifikation
+
+| Parameter       | Typ       | Beschreibung                                                          | Standard     |
+| --------------- | --------- | --------------------------------------------------------------------- | ------------ |
+| `version`       | `string`  | Kubernetes-Version (`major.minor`) — siehe [Versionen](#version)      | `v1.35`      |
+| `storageClass`  | `string`  | Speicherklasse für persistente Volumes                                | `replicated` |
+| `host`          | `string`  | Externer Hostname des Clusters. Standardmäßig `<cluster>.<tenant-host>` | `""`       |
+| `controlPlane`  | `object`  | Konfiguration der Steuerungsebene — siehe [Konzepte](concepts.md#control-plane) | `{}` |
+| `nodeGroups`    | `object`  | Map der Worker-Gruppen — siehe [nodeGroups](#nodegroups)              | siehe Standard |
+| `addons`        | `object`  | Zusatzmodule des Clusters — siehe [addons](#addons)                   | `{}`         |
+
+---
+
+## version
+
+`version` wählt die bereitzustellende Kubernetes-Minor-Version aus.
+
+| Unterstützte Werte |
+| ------------------ |
+| `v1.35` (Standard), `v1.34`, `v1.33`, `v1.32`, `v1.31`, `v1.30` |
+
+```yaml
+spec:
+  version: v1.34
+```
+
+Siehe den Leitfaden [Einen Cluster aktualisieren](how-to/upgrade-cluster.md) für das Versions-Upgrade.
+
+---
+
+## nodeGroups
+
+`nodeGroups` ist eine **Map** (`<name>: {…}`), die die Worker-Gruppen beschreibt. Jede Gruppe wird zwischen `minReplicas` und `maxReplicas` automatisch skaliert.
+
+| Feld               | Typ             | Beschreibung                                                      | Standard    |
+| ------------------ | --------------- | ----------------------------------------------------------------- | ----------- |
+| `minReplicas`      | `integer`       | Minimale Anzahl von Knoten (0 = Skalierung auf Null möglich)      | `0`         |
+| `maxReplicas`      | `integer`       | Maximale Anzahl von Knoten                                        | `10`        |
+| `instanceType`     | `string`        | Gabarit der Knoten (siehe [Instanztypen](../compute/api-reference.md#instanztypen)) | `u1.medium` |
+| `ephemeralStorage` | `int`/`string`  | Größe des ephemeren Speichers pro Knoten (z.B.: `20Gi`)          | `20Gi`      |
+| `resources`        | `object`        | Explizite Überschreibung von `cpu` / `memory` pro Knoten         | `{}`        |
+| `gpus`             | `[]object`      | An die Knoten angehängte GPUs (`gpus[].name`) — siehe [GPU mit Kubernetes](../gpu/api-reference.md) | `[]` |
+| `roles`            | `[]string`      | Rollen der Knoten (z.B.: `ingress-nginx`)                        | `[]`        |
+
+:::note `ephemeralStorage` ist ein Skalar
+Geben Sie direkt eine Größe an (`ephemeralStorage: 20Gi`), kein Objekt `{size: …}`.
+:::
+
+```yaml
+spec:
+  nodeGroups:
+    workers:
+      minReplicas: 1
+      maxReplicas: 10
+      instanceType: u1.xlarge
+      ephemeralStorage: 50Gi
+      roles:
+        - ingress-nginx
+    gpu-workers:
+      minReplicas: 0
+      maxReplicas: 4
+      instanceType: u1.2xlarge
+      ephemeralStorage: 200Gi
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
+```
+
+Siehe [Konzepte → Node Groups](concepts.md#node-groups) für die Details der Felder.
+
+---
+
+## addons
+
+Der Block `addons` aktiviert die im Tenant-Cluster installierten Zusatzmodule. Die meisten stellen `enabled` und `valuesOverride` (Überschreibung von Helm-Werten) bereit.
+
+| Addon                  | Felder                                          | Rolle                                                     |
+| ---------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `certManager`          | `enabled`, `valuesOverride`                     | Automatische Verwaltung der TLS-Zertifikate               |
+| `ingressNginx`         | `enabled`, `exposeMethod`, `hosts`, `valuesOverride` | Ingress-NGINX-Controller (siehe unten)               |
+| `fluxcd`               | `enabled`, `valuesOverride`                     | GitOps (Flux)                                             |
+| `gatewayAPI`           | `enabled`                                       | Unterstützung der Gateway API                             |
+| `gpuOperator`          | `enabled`, `valuesOverride`                     | NVIDIA GPU Operator (**erforderlich** für GPU-Workers)    |
+| `monitoringAgents`     | `enabled`, `valuesOverride`                     | Monitoring-/Log-Agents                                    |
+| `velero`               | `enabled`, `valuesOverride`                     | Sicherung / Wiederherstellung                             |
+| `cilium`               | `valuesOverride`                                | CNI Cilium (immer aktiv, nur Überschreibung)              |
+| `coredns`              | `valuesOverride`                                | CoreDNS (immer aktiv, nur Überschreibung)                 |
+| `verticalPodAutoscaler`| `valuesOverride`                                | Vertical Pod Autoscaler (immer aktiv)                     |
+
+:::note
+`cilium`, `coredns` und `verticalPodAutoscaler` haben kein `enabled`-Feld (Basiskomponenten) — nur `valuesOverride` ist nutzbar. `gatewayAPI` stellt ausschließlich `enabled` bereit.
+:::
+
+### certManager / fluxcd / velero / monitoringAgents / gpuOperator
+
+```yaml
+spec:
+  addons:
+    certManager:
+      enabled: true
+    gpuOperator:
+      enabled: true     # unverzichtbar, wenn nodeGroups GPUs tragen
+    velero:
+      enabled: true
+    monitoringAgents:
+      enabled: true
+    fluxcd:
+      enabled: true
+```
+
+### ingressNginx
+
+| Feld             | Typ        | Beschreibung                                                                 | Standard   |
+| ---------------- | ---------- | ---------------------------------------------------------------------------- | ---------- |
+| `enabled`        | `boolean`  | Aktiviert den Controller (erfordert Knoten mit der Rolle `ingress-nginx`)    | `false`    |
+| `exposeMethod`   | `string`   | Expositionsmethode: `Proxied` oder `LoadBalancer`                            | `Proxied`  |
+| `hosts`          | `[]string` | Domains, die zu diesem Cluster geroutet werden, wenn `exposeMethod: Proxied` | `[]`       |
+| `valuesOverride` | `object`   | Überschreibung von Helm-Werten                                               | `{}`       |
+
+```yaml
+spec:
+  addons:
+    ingressNginx:
+      enabled: true
+      exposeMethod: Proxied
+      hosts:
+        - app.example.com
+        - "*.services.example.com"
+```
+
+---
+
+## Vollständige Beispiele
+
+### Produktions-Cluster
 
 ```yaml title="production-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: production
-  namespace: company-prod
-  labels:
-    environment: production
-    criticality: high
-    team: platform
 spec:
-  # Cluster-Konfiguration
-  host: "k8s-prod.company.com"
-  storageClass: "replicated"
+  version: v1.34
+  storageClass: replicated
+  host: k8s-prod.example.com
 
-  # Hochverfügbare Steuerungsebene
   controlPlane:
     replicas: 3
 
-  # Spezialisierte Node Groups
   nodeGroups:
-    # Allgemeine Knoten mit Ingress
     web:
       minReplicas: 3
       maxReplicas: 10
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Compute-Knoten für intensive Workloads
     compute:
       minReplicas: 1
       maxReplicas: 5
-      instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
+      instanceType: u1.4xlarge
       ephemeralStorage: 100Gi
       roles: []
 
-    # Dedizierte Monitoring-Knoten
-    monitoring:
-      minReplicas: 2
-      maxReplicas: 4
-      instanceType: "m1.xlarge"   # 4 vCPU, 32 GB RAM
-      ephemeralStorage: 200Gi
-      roles:
-        - monitoring
-
-  # Vollständige Add-ons
   addons:
-    # Automatische SSL-Zertifikate
     certManager:
       enabled: true
-      valuesOverride:
-        prometheus:
-          enabled: true
-
-    # HTTP/HTTPS-Exposition
     ingressNginx:
       enabled: true
+      exposeMethod: Proxied
       hosts:
-        - "app.company.com"
-        - "api.company.com"
-        - "*.services.company.com"
-      valuesOverride:
-        controller:
-          replicaCount: 3
-          resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
-
-    # GitOps für Bereitstellungen
+        - app.example.com
+        - api.example.com
     fluxcd:
       enabled: true
-      valuesOverride:
-        gitRepository:
-          url: "https://github.com/company/k8s-production"
-          branch: "main"
-
-    # Vollständiges Monitoring
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        fluentbit:
-          enabled: true
+    velero:
+      enabled: true
 ```
 
-## **Entwicklungs-Cluster**
+### Entwicklungs-Cluster
 
 ```yaml title="development-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: development
-  namespace: company-dev
-  labels:
-    environment: development
-    auto-cleanup: "7d"
 spec:
-  # Basiskonfiguration
-  host: "k8s-dev.company.local"
-  storageClass: "replicated"
+  storageClass: replicated
 
-  # Minimale Steuerungsebene
   controlPlane:
-    replicas: 1  # Ressourcen sparen
+    replicas: 1   # Ressourcenersparnis (keine HA)
 
-  # Einzelne Allzweck-Node Group
   nodeGroups:
     general:
       minReplicas: 1
       maxReplicas: 3
-      instanceType: "s1.medium"
+      instanceType: s1.medium
       ephemeralStorage: 30Gi
       roles:
         - ingress-nginx
 
-  # Nur wesentliche Add-ons
   addons:
     certManager:
       enabled: true
-
     ingressNginx:
       enabled: true
       hosts:
-        - "*.dev.company.local"
-      valuesOverride:
-        controller:
-          replicaCount: 1  # Minimale Replikation
+        - "*.dev.example.com"
 ```
 
-## **ML/AI-Cluster mit GPU**
+### ML/AI-Cluster mit GPU
 
 ```yaml title="ml-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: machine-learning
-  namespace: company-ai
-  labels:
-    environment: ai
-    workload: gpu
 spec:
-  host: "k8s-ai.company.com"
-  storageClass: "fast-ssd"  # Hochleistungsspeicher
+  storageClass: replicated
 
   controlPlane:
     replicas: 2
 
   nodeGroups:
-    # Standardknoten für Orchestrierung
     system:
       minReplicas: 2
       maxReplicas: 4
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # GPU-Knoten für ML-Workloads
     gpu:
-      minReplicas: 0      # Skalierung auf Null möglich
+      minReplicas: 0          # Skalierung auf Null außerhalb der Last
       maxReplicas: 10
-      instanceType: "u1.2xlarge"
-      gpus: # Instanz mit GPU
-        - name: nvidia.com/AD102GL_L40S # Nvidia L40S
-      ephemeralStorage: 500Gi      # Großer Speicher für Datasets
+      instanceType: u1.2xlarge
+      ephemeralStorage: 500Gi # Datasets
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
       roles: []
 
   addons:
     certManager:
       enabled: true
-
+    # Erforderlich, um die GPUs den Pods bereitzustellen (nvidia.com/gpu)
+    gpuOperator:
+      enabled: true
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        # Spezialisiertes GPU-Monitoring
-        dcgmExporter:
-          enabled: true
 ```
 
----
-
-:::tip 💡 Best Practices
-
-- **Verwenden Sie Labels**, um Ihre Cluster nach Umgebung zu organisieren
-- **Konfigurieren Sie RBAC** von Beginn an, um den Zugriff abzusichern
-- **Aktivieren Sie das Monitoring** für vollständige Observability
-- **Planen Sie die Kapazität** mit geeigneten Node Groups
-- **Testen Sie die Sicherungen** regelmäßig
+:::tip Best Practices
+- `controlPlane.replicas: 3` in der Produktion (etcd-Quorum / HA).
+- Trennen Sie die Workloads in dedizierte Node Groups (web, compute, GPU).
+- Für GPUs: Node Group mit `gpus` **und** `addons.gpuOperator.enabled: true`.
+- Aktivieren Sie das Monitoring und die Sicherungen (Velero) auf kritischen Clustern.
 :::
 
-:::warning ⚠️ Achtung
-
-- **Löschungen sind irreversibel** — denken Sie an Sicherungen
-- **Updates** können Auswirkungen auf die Workloads haben
-- **Prüfen Sie die Kompatibilität** der Add-ons mit den Kubernetes-Versionen
+:::warning Achtung
+- Cluster-Löschungen sind **irreversibel** — überprüfen Sie Ihre Sicherungen.
+- Ohne das Addon `gpuOperator` werden die an die Workers angehängten GPUs den Pods nicht bereitgestellt.
 :::

--- a/i18n/de/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
@@ -216,13 +216,12 @@ Das Feld `nodeGroup` definiert die Konfiguration einer Knotengruppe (Workers) in
 Es ermöglicht die Angabe des Instanztyps, der Ressourcen, der Anzahl der Replikas sowie der zugehörigen Rollen und GPUs.
 
 ```yaml title="node-group.yaml"
-nodeGroup:
+nodeGroups:
   <name>:
-    ephemeralStorage:
-      size: 100Gi
+    ephemeralStorage: 100Gi
     gpus:
       - name: nvidia.com/AD102GL_L40S
-    instanceType: m5.large
+    instanceType: u1.xlarge
     maxReplicas: 5
     minReplicas: 2
     resources:
@@ -234,10 +233,10 @@ nodeGroup:
 
 ---
 
-### `ephemeralStorage` (Object)
+### `ephemeralStorage` (string)
 
-Definiert die Konfiguration des **ephemeren Speichers**, der den Knoten der Gruppe zugeordnet ist.
-Dieser Speicher wird für temporäre Daten, Caches oder Logdateien verwendet.
+Definiert die Größe des **ephemeren Speichers** pro Knoten der Gruppe (z.B.: `100Gi`).
+Dieser Speicher wird für temporäre Daten, Caches oder Logdateien verwendet. Es ist ein Skalarwert (kein Objekt `{size: …}`).
 
 ### `gpus` (Array)
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/tools/terraform.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/tools/terraform.md
@@ -80,6 +80,9 @@ resource "kubectl_manifest" "kubernetes_cluster" {
       namespace = "default"
     }
     spec = {
+      version      = "v1.34"
+      storageClass = "replicated"
+
       controlPlane = {
         replicas = 2
       }
@@ -90,11 +93,18 @@ resource "kubectl_manifest" "kubernetes_cluster" {
           maxReplicas      = 5
           instanceType     = "s1.large"
           ephemeralStorage = "50Gi"
-          roles = ["ingress-nginx"]
+          roles            = ["ingress-nginx"]
         }
+        # Beispiel für eine GPU-Knotengruppe (erfordert das gpuOperator-Addon unten)
+        # gpu = {
+        #   minReplicas      = 0
+        #   maxReplicas      = 4
+        #   instanceType     = "u1.2xlarge"
+        #   ephemeralStorage = "200Gi"
+        #   gpus             = [{ name = "nvidia.com/AD102GL_L40S" }]
+        #   roles            = []
+        # }
       }
-
-      storageClass = "replicated"
 
       addons = {
         certManager = {
@@ -106,6 +116,10 @@ resource "kubectl_manifest" "kubernetes_cluster" {
             "${var.cluster_name}.example.com"
           ]
         }
+        # Erforderlich, um GPUs den Pods einer GPU-Knotengruppe verfügbar zu machen
+        # gpuOperator = {
+        #   enabled = true
+        # }
       }
     }
   })
@@ -114,7 +128,7 @@ resource "kubectl_manifest" "kubernetes_cluster" {
 # Kubeconfig abrufen
 data "kubernetes_secret" "cluster_kubeconfig" {
   depends_on = [kubectl_manifest.kubernetes_cluster]
-
+  
   metadata {
     name      = "${var.cluster_name}-admin-kubeconfig"
     namespace = "default"
@@ -134,22 +148,45 @@ resource "local_file" "kubeconfig" {
 ### Virtuelle Maschine bereitstellen
 
 ```hcl title="virtual-machine.tf"
-resource "kubectl_manifest" "virtual_machine" {
+# Der Datenträger ist eine separate VMDisk-Ressource, auf die die VM verweist
+resource "kubectl_manifest" "vm_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "${var.vm_name}-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "50Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "virtual_machine" {
+  depends_on = [kubectl_manifest.vm_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = var.vm_name
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
 
-      systemDisk = {
-        size         = "50Gi"
-        storageClass = "replicated"
-      }
+      disks = [
+        {
+          name = "${var.vm_name}-disk"
+        }
+      ]
 
       external       = true
       externalMethod = "PortList"
@@ -165,14 +202,14 @@ resource "kubectl_manifest" "virtual_machine" {
             shell: /bin/bash
             ssh_authorized_keys:
               - ${var.ssh_public_key}
-
+        
         package_update: true
         packages:
           - curl
           - wget
           - git
           - docker.io
-
+        
         runcmd:
           - systemctl enable docker
           - systemctl start docker
@@ -186,28 +223,52 @@ resource "kubectl_manifest" "virtual_machine" {
 ### VM mit GPU bereitstellen
 
 ```hcl title="vm-gpu.tf"
-resource "kubectl_manifest" "vm_gpu" {
+resource "kubectl_manifest" "vm_gpu_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "gpu-vm-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "100Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "vm_gpu" {
+  depends_on = [kubectl_manifest.vm_gpu_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = "gpu-vm"
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
 
       gpus = [
         {
+          # Modelle: nvidia.com/AD102GL_L40S, nvidia.com/GA100_A100_PCIE_80GB,
+          # nvidia.com/GA100_A100_SXM4_80GB, nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION
           name = "nvidia.com/AD102GL_L40S"
         }
       ]
 
-      systemDisk = {
-        size         = "100Gi"
-        storageClass = "replicated"
-      }
+      disks = [
+        {
+          name = "gpu-vm-disk"
+        }
+      ]
 
       external       = true
       externalMethod = "PortList"
@@ -221,13 +282,13 @@ resource "kubectl_manifest" "vm_gpu" {
           - name: ubuntu
             sudo: ALL=(ALL) NOPASSWD:ALL
             shell: /bin/bash
-
+        
         package_update: true
         packages:
           - curl
           - wget
           - build-essential
-
+        
         runcmd:
           # NVIDIA-Treiber installieren
           - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
@@ -256,13 +317,13 @@ resource "kubectl_manifest" "postgres" {
       size         = "20Gi"
       replicas     = 2
       storageClass = "replicated"
-
+      
       users = {
         admin = {
           password = var.postgres_password
         }
       }
-
+      
       databases = {
         myapp = {
           roles = {
@@ -295,7 +356,7 @@ output "cluster_kubeconfig" {
 
 output "vm_status" {
   description = "Befehl zur Überprüfung des VM-Status"
-  value       = "kubectl get virtualmachine ${var.vm_name}"
+  value       = "kubectl get vminstance ${var.vm_name}"
 }
 
 output "postgres_connection" {

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
@@ -5,7 +5,9 @@ title: API Reference
 
 ## API Reference – Virtual Machines
 
-This reference provides a comprehensive description of Hikube **VMInstance** and **VMDisk** APIs, including available parameters, usage examples, and recommended best practices.
+This reference provides an exhaustive description of Hikube's **VMInstance** and **VMDisk** APIs: available parameters, default values, usage examples, and recommended best practices.
+
+The fields documented below correspond to the schema actually exposed by the platform (`apps.cozystack.io/v1alpha1`).
 
 ---
 
@@ -13,9 +15,9 @@ This reference provides a comprehensive description of Hikube **VMInstance** and
 
 ### Overview
 
-The `VMInstance` API allows you to create, configure, and manage virtual machines in Hikube.
+The `VMInstance` API lets you create, configure, and manage virtual machines in Hikube. A VM relies on one or more disks described separately via the [`VMDisk`](#vmdisk) resource.
 
-```yaml
+```yaml title="vm-instance.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -24,24 +26,60 @@ spec:
   # Detailed configuration below
 ```
 
+:::warning Correct Kind
+The resource is named **`VMInstance`** (not `VirtualMachine`). The disk is **not** a built-in `systemDisk` field: you must create a separate `VMDisk` resource and reference it in `disks`.
+:::
+
 ---
 
 ### Full specification
 
-#### General parameters
+| Parameter         | Type             | Description                                                                 | Default      | Required |
+| ----------------- | ---------------- | --------------------------------------------------------------------------- | ------------ | -------- |
+| `external`        | `boolean`        | Enables network exposure from outside the cluster                           | `false`      | no       |
+| `externalMethod`  | `string`         | Exposure method: `PortList` or `WholeIP`                                    | `PortList`   | no       |
+| `externalPorts`   | `[]integer`      | Ports to forward from the outside (used with `PortList`)                    | `[22]`       | no       |
+| `runStrategy`     | `string`         | Desired running state (see [runStrategy](#runstrategy))                     | `Always`     | no       |
+| `instanceType`    | `string`         | CPU / memory size (see [instance types](#instance-types))                   | `u1.medium`  | no       |
+| `instanceProfile` | `string`         | OS profile / preferences (drivers, kernel) — see [profiles](#os-profiles)   | `ubuntu`     | no       |
+| `disks`           | `[]object`       | List of `VMDisk` resources to attach (see [disks](#disks))                  | `[]`         | no       |
+| `subnets`         | `[]object`       | Additional subnets (VPC) — see [subnets](#subnets)                          | `[]`         | no       |
+| `gpus`            | `[]object`       | GPUs to attach in passthrough (see [gpus](#gpu))                            | `[]`         | no       |
+| `resources`       | `object`         | Explicit CPU / memory / sockets override (see [resources](#resources))      | `{}`         | no       |
+| `cpuModel`        | `string`         | CPU model exposed to the VM (e.g. `host-passthrough`)                        | `""`         | no       |
+| `sshKeys`         | `[]string`       | Injected public SSH keys                                                    | `[]`         | no       |
+| `cloudInit`       | `string`         | Cloud-init configuration (user-data YAML)                                   | `""`         | no       |
+| `cloudInitSeed`   | `string`         | Seed used to generate a stable SMBIOS UUID                                  | `""`         | no       |
 
-| Parameter         | Type       | Description                                  | Default    | Required |
-| ----------------- | ---------- | -------------------------------------------- | ---------- | -------- |
-| `external`        | `boolean`  | Enables external network exposure for the VM | `false`    | ✅        |
-| `externalMethod`  | `string`   | Exposure method (`PortList`, `WholeIP`)      | `PortList` | ✅        |
-| `externalPorts`   | `[]int`    | List of externally exposed ports             | `[]`       | ✅        |
-| `running`         | `boolean`  | Desired VM running state                     | `true`     | ✅        |
-| `instanceType`    | `string`   | CPU / memory instance size                   | –          | ✅        |
-| `instanceProfile` | `string`   | OS profile for the VM                        | –          | ✅        |
-| `disks`           | `[]string` | List of attached `VMDisk` resources          | `[]`       | ✅        |
-| `sshKeys`         | `[]string` | Injected public SSH keys                     | `[]`       | ✅        |
-| `cloudInit`       | `string`   | Cloud-init configuration (YAML)              | `""`       | ✅        |
-| `cloudInitSeed`   | `string`   | Cloud-init seed data                         | `""`       | ✅        |
+:::note
+All fields are optional: a minimal VM only requires a bootable disk referenced in `disks`. The default values above are those applied by the platform.
+:::
+
+---
+
+### runStrategy
+
+`runStrategy` controls the VM running state. It replaces the former boolean `running` field.
+
+| Value             | Behavior                                                                |
+| ----------------- | ----------------------------------------------------------------------- |
+| `Always`          | The VM is kept running (restarts automatically if it stops)             |
+| `Halted`          | The VM is stopped                                                       |
+| `Manual`          | The state is driven manually (`virtctl start` / `stop`)                 |
+| `RerunOnFailure`  | Restarts only after a failure                                           |
+| `Once`            | Starts once, without automatic restart                                  |
+
+```yaml
+spec:
+  runStrategy: Always
+```
+
+To stop/restart an existing VM:
+
+```bash
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Halted"}}'
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Always"}}'
+```
 
 ---
 
@@ -57,29 +95,22 @@ spec:
     - 443
 ```
 
+See [Network exposure methods](#network-exposure-methods).
+
 ---
 
 ### Instance types
 
-#### S Series – Standard (1:2 ratio)
+`instanceType` references a `VirtualMachineClusterInstancetype`. Hikube exposes several series, each with sizes from `nano` → `8xlarge`:
 
-General-purpose workloads, shared and burstable CPU.
-
-```yaml
-instanceType: s1.small     # 1 vCPU, 2 GB RAM
-instanceType: s1.medium    # 2 vCPU, 4 GB RAM
-instanceType: s1.large     # 4 vCPU, 8 GB RAM
-instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
-instanceType: s1.3large    # 12 vCPU, 24 GB RAM
-instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
-instanceType: s1.3xlarge   # 24 vCPU, 48 GB RAM
-instanceType: s1.4xlarge   # 32 vCPU, 64 GB RAM
-instanceType: s1.8xlarge   # 64 vCPU, 128 GB RAM
-```
-
-#### U Series – Universal (1:4 ratio)
+| Series | Usage                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| `s1`   | **Standard** — shared/burstable CPUs, 1:2 vCPU:RAM ratio              |
+| `u1`   | **Universal** — general purpose, 1:4 ratio (default)                 |
+| `m1`   | **Memory optimized** — 1:8 ratio                                     |
 
 ```yaml
+# Examples from the Universal series (1:4 ratio)
 instanceType: u1.medium    # 1 vCPU, 4 GB RAM
 instanceType: u1.large     # 2 vCPU, 8 GB RAM
 instanceType: u1.xlarge    # 4 vCPU, 16 GB RAM
@@ -88,9 +119,17 @@ instanceType: u1.4xlarge   # 16 vCPU, 64 GB RAM
 instanceType: u1.8xlarge   # 32 vCPU, 128 GB RAM
 ```
 
-#### M Series – Memory Optimized (1:8 ratio)
+```yaml
+# Standard series (1:2 ratio)
+instanceType: s1.small     # 1 vCPU, 2 GB RAM
+instanceType: s1.medium    # 2 vCPU, 4 GB RAM
+instanceType: s1.large     # 4 vCPU, 8 GB RAM
+instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
+instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
+```
 
 ```yaml
+# Memory optimized series (1:8 ratio)
 instanceType: m1.large     # 2 vCPU, 16 GB RAM
 instanceType: m1.xlarge    # 4 vCPU, 32 GB RAM
 instanceType: m1.2xlarge   # 8 vCPU, 64 GB RAM
@@ -98,11 +137,110 @@ instanceType: m1.4xlarge   # 16 vCPU, 128 GB RAM
 instanceType: m1.8xlarge   # 32 vCPU, 256 GB RAM
 ```
 
+:::tip GPU and `instanceType`
+To attach a GPU, choose a general-purpose series (`u1`, `s1`…) and declare the GPU via the [`gpus`](#gpu) field. The NVIDIA driver requires **at least 4 GiB of RAM**.
+:::
+
 ---
 
-### Supported OS profiles
+### OS profiles
 
-*(List preserved as-is, Linux and Windows profiles)*
+`instanceProfile` loads the **KubeVirt preferences** (drivers, machine model, kernel) suited to the OS. It does **not** define the image — that is carried by the `VMDisk`. It is especially decisive for Windows (virtio drivers).
+
+Available values (excerpt):
+
+| Family      | Profiles                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| Ubuntu      | `ubuntu`                                                                                 |
+| RHEL        | `rhel.7`, `rhel.8`, `rhel.9`, `rhel.10` (+ variants `.desktop`, `.arm64`, `.dpdk`, `.realtime`) |
+| CentOS      | `centos.7`, `centos.stream8`, `centos.stream9`, `centos.stream10` (+ `.desktop`, `.dpdk`) |
+| Fedora      | `fedora`, `fedora.arm64`                                                                  |
+| openSUSE    | `opensuse.leap`, `opensuse.tumbleweed`                                                    |
+| SLES        | `sles`                                                                                    |
+| Others      | `alpine`, `cirros`                                                                        |
+| Windows     | `windows.2k22.virtio`, `windows.2k25.virtio`, `windows.10.virtio`, `windows.11.virtio` (the `.virtio` variants are **recommended**); non-virtio variants are also available (`windows.2k22`…) |
+
+:::note
+There is **no** dedicated `debian`, `rocky`, or `almalinux` profile. For those distributions, use `ubuntu` (Debian base) or leave `instanceProfile: ""`. For Windows, always use a `.virtio` variant (e.g. `windows.2k25.virtio`) so that the virtio drivers are loaded.
+:::
+
+---
+
+### Disks
+
+`disks` is a **list of objects** referencing [`VMDisk`](#vmdisk) resources by name. The first disk listed is usually the bootable disk.
+
+| Field           | Type     | Description                                          |
+| --------------- | -------- | ---------------------------------------------------- |
+| `disks[].name`  | `string` | Name of the `VMDisk` to attach                       |
+| `disks[].bus`   | `string` | Bus type (`virtio`, `sata`, `scsi`) — optional      |
+
+```yaml
+spec:
+  disks:
+    - name: vm-system-disk
+    - name: vm-data-disk
+      bus: scsi
+```
+
+:::warning
+The VM does not take a new disk into account until it is restarted (`virtctl restart` or a `runStrategy` toggle).
+:::
+
+---
+
+### GPU
+
+`gpus` attaches one or more NVIDIA GPUs in PCI passthrough.
+
+| Field          | Type     | Description                                |
+| -------------- | -------- | ------------------------------------------ |
+| `gpus[].name`  | `string` | Name of the GPU resource (`nvidia.com/...`) |
+
+```yaml
+spec:
+  instanceType: u1.2xlarge
+  gpus:
+    - name: nvidia.com/AD102GL_L40S
+```
+
+The models available on Hikube are detailed in the [GPU API reference](../gpu/api-reference.md). A GPU is assigned **exclusively** to a single VM.
+
+---
+
+### Subnets
+
+`subnets` attaches the VM to additional subnets of a VPC.
+
+| Field             | Type     | Description           |
+| ----------------- | -------- | --------------------- |
+| `subnets[].name`  | `string` | Subnet name           |
+
+```yaml
+spec:
+  subnets:
+    - name: subnet-ab2c3e47
+```
+
+---
+
+### Resources
+
+By default, CPU/memory sizing is carried by `instanceType`. The `resources` block lets you explicitly **override** those values (and define a socket topology).
+
+| Field                | Type            | Description                          |
+| -------------------- | --------------- | ------------------------------------ |
+| `resources.cpu`      | `int`/`string`  | Number of allocated CPU cores        |
+| `resources.memory`   | `int`/`string`  | Amount of allocated memory           |
+| `resources.sockets`  | `int`/`string`  | Number of CPU sockets (topology)     |
+
+```yaml
+spec:
+  resources:
+    cpu: "4"
+    memory: 8Gi
+    sockets: "2"
+```
 
 ---
 
@@ -128,11 +266,11 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
         ssh_authorized_keys:
           - ssh-rsa AAAA...
-
     packages:
       - htop
       - docker.io
-      - curl
+  # Optional seed to pin the SMBIOS UUID (licensing, machine identity)
+  cloudInitSeed: ""
 ```
 
 ---
@@ -149,11 +287,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.2xlarge
   instanceProfile: ubuntu
   disks:
-    - vm-system-disk
+    - name: vm-system-disk
   sshKeys:
     - ssh-rsa AAAA...
 ```
@@ -164,33 +302,30 @@ spec:
 
 ### Overview
 
-The `VMDisk` API manages virtual disks attached to virtual machines.
-It supports **multiple image sources**: HTTP, empty disks, and **Golden Images**.
+The `VMDisk` API manages the virtual disks attached to VMs. It supports several image sources: **HTTP**, a preloaded **Golden Image**, or an empty disk.
 
-```yaml
+```yaml title="disk-example.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMDisk
 metadata:
   name: disk-example
 spec:
   source:
-    http:
-      url: https://...
+    image:
+      name: ubuntu-2404
   optical: false
   storage: 30Gi
   storageClass: replicated
 ```
 
----
-
 ### Main parameters
 
-| Parameter      | Type      | Description        | Default      | Required |
-| -------------- | --------- | ------------------ | ------------ | -------- |
-| `source`       | `object`  | Disk image source  | `{}`         | ✅        |
-| `optical`      | `boolean` | Optical disk (ISO) | `false`      | ✅        |
-| `storage`      | `string`  | Disk size          | –            | ✅        |
-| `storageClass` | `string`  | Storage class      | `replicated` | ✅        |
+| Parameter      | Type            | Description                                  | Default      | Required |
+| -------------- | --------------- | -------------------------------------------- | ------------ | -------- |
+| `storage`      | `int`/`string`  | Disk size                                    | `5Gi`        | ✅       |
+| `storageClass` | `string`        | Storage class                                | `replicated` | ✅       |
+| `source`       | `object`        | Disk image source (see below)                | `{}`         | no       |
+| `optical`      | `boolean`       | Optical disk / ISO (installer)               | `false`      | no       |
 
 ---
 
@@ -205,28 +340,9 @@ spec:
       url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 ```
 
----
-
-### Empty disk
-
-```yaml
-spec:
-  source: {}
-```
-
----
-
 ### Golden Images (Hikube preloaded images)
 
-**Golden Images** are OS images preloaded and maintained by Hikube.
-They allow **fast provisioning**, standardization, and no external network dependency.
-
-:::tip Naming convention
-Images follow the `{os}-{version}` format (e.g., `ubuntu-2404`, `rocky-9`).
-Always specify the version to ensure workload compatibility.
-:::
-
-#### Usage
+**Golden Images** are system images maintained and preloaded in Hikube, for fast provisioning without an external dependency.
 
 ```yaml
 spec:
@@ -238,7 +354,7 @@ spec:
 #### Available images
 
 | Name | Operating System | Type | Min. storage |
-| --- | ---------------- | ---- | :----------: |
+| --- | ---------------------- | ---- | :-----------: |
 | `almalinux-8` | AlmaLinux 8 | Cloud | 11 Gi |
 | `almalinux-9` | AlmaLinux 9 | Cloud | 11 Gi |
 | `almalinux-10` | AlmaLinux 10 | Cloud | 11 Gi |
@@ -259,20 +375,28 @@ spec:
 | `opensuse-160` | openSUSE Leap 16.0 | Cloud | 2 Gi |
 | `cloudlinux-8` | CloudLinux 8 | Cloud | 8 Gi |
 | `cloudlinux-9` | CloudLinux 9 | Cloud | 9 Gi |
+| `windows-server-2022` | Windows Server 2022 | ISO | 28 Gi |
+| `windows-server-2025` | Windows Server 2025 | ISO | 28 Gi |
 | `proxmox-8` | Proxmox VE 8 | ISO | 2 Gi |
 | `proxmox-9` | Proxmox VE 9 | ISO | 2 Gi |
 | `talos-112` | Talos Linux 1.12 | Cloud | 8 Gi |
 
 :::warning ISO images
-**ISO** type images (Proxmox) are installers, not ready-to-use cloud images.
-They require manual installation through the VNC console.
+**ISO** type images (Windows, Proxmox) are installers, not ready-to-use cloud images. Plan for an initial installation through the VNC console. For Windows, see the [Install a Windows VM](how-to/install-windows-vm.md) guide.
 :::
+
+### Empty disk
+
+```yaml
+spec:
+  source: {}
+```
+
+An empty disk is useful for additional data volumes.
 
 ---
 
-### VMDisk examples
-
-#### System disk using a Golden Image
+### VMDisk example using a Golden Image
 
 ```yaml title="ubuntu-golden-disk.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
@@ -292,10 +416,22 @@ spec:
 
 ## Storage classes
 
-| Class        | Description        | Replication |
-| ------------ | ------------------ | ----------- |
-| `local`      | Node-local storage | ❌           |
-| `replicated` | Replicated storage | ✅           |
+Hikube exposes several `storageClass` options based on LINSTOR. For a VM, `replicated` is recommended.
+
+| Class                                  | Replication | Encryption  | Notes                                            |
+| -------------------------------------- | :---------: | :---------: | ------------------------------------------------ |
+| `local`                                | ❌          | ❌          | Node-local storage (default), not resilient      |
+| `local-encrypted`                      | ❌          | ✅ (LUKS)   | Local + encrypted                                |
+| `replicated`                           | ✅          | ❌          | Synchronous replication — **recommended** for VMs |
+| `replicated-encrypted`                 | ✅          | ✅ (LUKS)   | Replicated + encrypted                           |
+| `replicated-async`                     | ✅ (async)  | ❌          | Asynchronous replication                         |
+| `replicated-async-encrypted`           | ✅ (async)  | ✅ (LUKS)   | Asynchronous replication + encrypted             |
+| `replicated-async-windows`             | ✅ (async)  | ❌          | Variant tailored for Windows disks               |
+| `replicated-async-windows-encrypted`   | ✅ (async)  | ✅ (LUKS)   | Windows variant + encrypted                      |
+
+:::note
+The `-windows` variants are optimized for Windows VM disks. Encryption (`-encrypted`) relies on LUKS at the volume level.
+:::
 
 ---
 
@@ -304,18 +440,17 @@ spec:
 ### PortList
 
 * Automatic firewall
-* Explicit port allowlist
-* **Recommended for production**
+* Only the ports listed in `externalPorts` are accessible
+* **Recommended in production**
 
 ### WholeIP
 
-* All ports exposed
-* No network filtering
-* Development use only
+* A dedicated public IP, all ports exposed
+* No network filtering on the platform side
+* Reserve for development or controlled gateways
 
 :::warning Security
-With `WholeIP`, the VM is fully exposed to the Internet.
-An OS-level firewall is mandatory.
+With `WholeIP`, the VM is fully exposed to the Internet. An OS-level firewall is mandatory.
 :::
 
 ---
@@ -324,19 +459,19 @@ An OS-level firewall is mandatory.
 
 ### Security
 
-* Use SSH keys only
-* Enable OS firewall
+* SSH key authentication only
+* OS firewall active, `PortList` rather than `WholeIP`
 
 ### Storage
 
-* Use `replicated` in production
-* Separate system and data disks
+* `replicated` (or encrypted/Windows variants) in production
+* Separate the system disk from data disks
 
 ### Performance
 
-* Select instance types according to workload
-* Monitor real usage
+* Match `instanceType` to the workload, or override via `resources`
+* For GPUs, plan for ≥ 4 GiB of RAM and a suitable CPU/RAM ratio
 
 :::tip Recommended architecture
-For production, use at least **two disks** (system + data) with replicated storage.
+In production, use at least **2 disks** (system + data) with replicated storage.
 :::

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/compute/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/compute/faq.md
@@ -68,7 +68,7 @@ kind: VMDisk
 metadata:
   name: data-volume
 spec:
-  size: 100Gi
+  storage: 100Gi
   storageClass: replicated
 ```
 
@@ -81,7 +81,7 @@ spec:
   instanceType: u1.large
   instanceProfile: ubuntu
   disks:
-    - data-volume
+    - name: data-volume
 ```
 
 ---
@@ -149,7 +149,7 @@ Cloud-init runs at the first boot of the VM and allows installing packages, crea
 
 | Parameter | Role | Examples |
 |-----------|------|----------|
-| `instanceProfile` | Loads the **drivers and kernels** adapted to the OS | `ubuntu`, `centos`, `windows.2k25.virtio` |
+| `instanceProfile` | Loads the **drivers and kernels** adapted to the OS | `ubuntu`, `centos.stream9`, `windows.2k25.virtio` |
 | `instanceType` | Defines the VM **size** (CPU/RAM) | `s1.small`, `u1.large`, `m1.2xlarge` |
 
 `instanceProfile` does not determine the OS image — that is defined in the **VMDisk** resource via `source.image.name`. The profile loads optimized drivers and kernels for the operating system. It is mainly useful for **Windows** (virtio drivers). `instanceType` sizes the CPU and memory resources allocated to the VM.

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
@@ -67,8 +67,8 @@ spec:
   externalPorts:
     - 22
   disks:
-    - vm-system-disk
-    - vm-data-disk
+    - name: vm-system-disk
+    - name: vm-data-disk
   sshKeys:
     - ssh-ed25519 AAAA... user@host
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
@@ -98,14 +98,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.xlarge
   instanceProfile: "ubuntu"
   disks:
-    - name: disk-example # Specify your disk name
-  resources:
-    cpu: ""
-    memory: ""
+    - name: disk-example # Name of the VMDisk to attach
   sshKeys:
     - your-public-key-here
   cloudInit: |

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
@@ -107,7 +107,7 @@ This issue affects all distributions using `systemd-resolved` (Ubuntu 22.04+, De
    ```yaml title="vm.yaml"
    spec:
      disks:
-       - data-volume  # Must match the VMDisk metadata.name
+       - name: data-volume  # Must match the VMDisk metadata.name
    ```
 
 2. Check the VMDisk status:
@@ -116,7 +116,7 @@ This issue affects all distributions using `systemd-resolved` (Ubuntu 22.04+, De
    kubectl describe vmdisk data-volume
    ```
 
-3. The available storageClasses on Hikube are: `local`, `replicated`, and `replicated-async`. For a VM (single instance), `replicated` is recommended.
+3. The storageClasses available on Hikube are: `local`, `local-encrypted`, `replicated`, `replicated-encrypted`, `replicated-async`, `replicated-async-encrypted`, `replicated-async-windows`, and `replicated-async-windows-encrypted`. For a VM (single instance), `replicated` is recommended.
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
@@ -5,74 +5,85 @@ title: API Reference
 
 # API Reference - GPU
 
-This reference details the APIs for using GPUs on Hikube, whether with virtual machines or Kubernetes clusters.
+This reference details how to use GPUs on Hikube, whether with virtual machines (`VMInstance`) or managed Kubernetes clusters (`Kubernetes`).
+
+---
+
+## 🎮 Available GPUs
+
+GPUs are attached by their **resource name** (`nvidia.com/<model>`). The models available on Hikube:
+
+| GPU | Resource name | Architecture | Memory | Typical usage |
+|-----|------------------|--------------|---------|---------------|
+| **L40S** | `nvidia.com/AD102GL_L40S` | Ada Lovelace | 48 GB GDDR6 | Inference, dev, rendering |
+| **A100 PCIe 80 GB** | `nvidia.com/GA100_A100_PCIE_80GB` | Ampere | 80 GB HBM2e | ML training |
+| **A100 SXM4 80 GB** | `nvidia.com/GA100_A100_SXM4_80GB` | Ampere | 80 GB HBM2e | ML training (multi-GPU NVLink) |
+| **RTX PRO 6000 Blackwell** | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` | Blackwell | 96 GB GDDR7 | LLM, intensive computing |
+
+:::note Availability
+The available GPU hardware varies by zone. Check the allocatable resources on the platform side before planning a workload. The NVIDIA driver requires **at least 4 GiB of RAM** on the VM or worker.
+:::
 
 ---
 
 ## 🖥️ GPU with Virtual Machines
 
-### **VirtualMachine API**
+On a VM, the GPU is attached in **PCI passthrough** (exclusive allocation) via the `gpus` field of a [`VMInstance`](../compute/api-reference.md) resource. The disk is defined separately by a [`VMDisk`](../compute/api-reference.md#vmdisk) resource.
 
-```yaml
+```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
-#### **GPU Parameters for VM**
+:::warning Common pitfalls
+- The resource is named **`VMInstance`** (not `VirtualMachine`).
+- The state is driven via **`runStrategy: Always`** (not `running: true`).
+- The disk is **not** a built-in `systemDisk` field: create a `VMDisk` resource and reference it in `disks` (a list of `{name}` objects).
+:::
+
+### GPU parameters for VM
 
 | **Parameter** | **Type** | **Description** | **Required** |
 |---------------|----------|-----------------|------------|
-| `gpus` | `[]GPU` | List of GPUs to attach | ✅ |
-| `gpus[].name` | `string` | NVIDIA GPU type | ✅ |
+| `gpus` | `[]object` | List of GPUs to attach | no |
+| `gpus[].name` | `string` | GPU resource name (`nvidia.com/...`) | yes (if `gpus` is set) |
 
-#### **Available GPU Types**
+### Complete GPU VM example
 
-```yaml
-# GPU for inference and development
-gpus:
-  - name: "nvidia.com/AD102GL_L40S"
-
-# GPU for ML training
-gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"
-
-# GPU for LLM and exascale computing
-gpus:
-  - name: "nvidia.com/H100_94GB"
-```
-
-#### **Hardware Specifications**
-
-| **GPU** | **Architecture** | **Memory** | **Performance** |
-|---------|------------------|-------------|-----------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) |
-
-#### **Complete GPU VM Example**
-
-```yaml
+```yaml title="ai-workstation.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMDisk
+metadata:
+  name: ai-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMInstance
 metadata:
   name: ai-workstation
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.2xlarge  # 8 vCPU, 32 GB RAM
   gpus:
     - name: "nvidia.com/GA100_A100_PCIE_80GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+  disks:
+    - name: ai-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -83,37 +94,46 @@ spec:
     users:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
-    
     packages:
       - python3-pip
       - build-essential
-    
     runcmd:
-      # NVIDIA drivers
-      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-      - dpkg -i cuda-keyring_1.0-1_all.deb
+      # NVIDIA drivers + CUDA (see the dedicated guide for the exact version)
+      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+      - dpkg -i cuda-keyring_1.1-1_all.deb
       - apt-get update
-      - apt-get install -y cuda-toolkit nvidia-driver-535
-      
+      - apt-get install -y cuda-toolkit nvidia-driver-570
       # PyTorch with CUDA
-      - pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+      - pip3 install torch torchvision
+```
+
+### Multi-GPU on VM
+
+```yaml
+spec:
+  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
+  gpus:
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
 ---
 
 ## ☸️ GPU with Kubernetes
 
-### **Kubernetes API with GPU Workers**
+On a managed Kubernetes cluster, GPUs are attached to the **node groups**, and the **`gpuOperator`** addon must be enabled to expose the GPUs to pods.
 
-```yaml
+```yaml title="cluster-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: cluster-gpu
 spec:
   controlPlane:
-    replicas: 1
-  
+    replicas: 2
+
   nodeGroups:
     gpu-workers:
       minReplicas: 1
@@ -122,16 +142,26 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Required: installs the NVIDIA drivers and the device plugin
+    gpuOperator:
+      enabled: true
 ```
 
-#### **GPU Parameters for NodeGroups**
+:::warning `gpuOperator` addon required
+Without `gpuOperator: enabled: true`, the workers' GPUs are not exposed to pods (`nvidia.com/gpu` stays at 0).
+:::
+
+### GPU parameters for NodeGroups
 
 | **Parameter** | **Type** | **Description** | **Required** |
 |---------------|----------|-----------------|------------|
-| `nodeGroups.<name>.gpus` | `[]GPU` | GPUs for workers | ❌ |
-| `gpus[].name` | `string` | NVIDIA GPU type | ✅ |
+| `nodeGroups.<name>.gpus` | `[]object` | GPUs attached to the group's workers | no |
+| `gpus[].name` | `string` | GPU resource name (`nvidia.com/...`) | yes (if `gpus` is set) |
+| `addons.gpuOperator.enabled` | `boolean` | Enables the NVIDIA GPU Operator | yes (to use the GPUs) |
 
-#### **Multi-GPU Configuration**
+### Multi-GPU configuration per worker
 
 ```yaml
 nodeGroups:
@@ -140,15 +170,17 @@ nodeGroups:
     maxReplicas: 2
     instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
     gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
-#### **Usage in Pods**
+### Usage in Pods
 
-```yaml
+Once `gpuOperator` is active, pods reserve GPUs via the `nvidia.com/gpu` resource:
+
+```yaml title="ml-training.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -156,194 +188,61 @@ metadata:
 spec:
   containers:
   - name: trainer
-    image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+    image: pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
     resources:
       limits:
         nvidia.com/gpu: 1
       requests:
         nvidia.com/gpu: 1
-    command:
-      - python
-      - train.py
-```
-
-#### **Multi-GPU Job**
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: distributed-training
-spec:
-  template:
-    spec:
-      containers:
-      - name: trainer
-        image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
-        resources:
-          limits:
-            nvidia.com/gpu: 4
-          requests:
-            nvidia.com/gpu: 4
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0,1,2,3"
-      restartPolicy: Never
+    command: ["python", "train.py"]
 ```
 
 ---
 
-## 📋 Approach Comparison
-
-### **VM GPU vs Kubernetes GPU**
+## 📋 VM GPU vs Kubernetes GPU
 
 | **Aspect** | **VM GPU** | **Kubernetes GPU** |
 |------------|------------|-------------------|
-| **Allocation** | 1 GPU = 1 VM (exclusive) | 1+ GPU per worker (shareable) |
-| **Isolation** | Complete at VM level | Namespace/Pod |
-| **Scaling** | Vertical (more GPUs) | Horizontal + Vertical |
-| **Management** | Manual via YAML | Orchestrated by K8s |
+| **Allocation** | 1 GPU = 1 VM (exclusive passthrough) | 1+ GPU per worker |
+| **Isolation** | Complete at VM level | Namespace / Pod |
+| **Scaling** | Vertical (more GPUs) | Horizontal + Vertical (autoscaling) |
+| **Management** | Manual via `VMInstance` | Orchestrated by Kubernetes |
 | **Sharing** | No | Yes (between pods) |
 | **Overhead** | Minimal | Orchestration overhead |
 
-### **When to use each approach**
+**VM GPU**: non-containerized applications, direct GPU access, dev/prototyping, rendering/CAD.
 
-#### **VM GPU recommended for:**
-
-- Legacy non-containerized applications
-- Need for direct and complete GPU access
-- Development and prototyping
-- Monolithic workloads
-- Graphics applications (rendering, CAD)
-
-#### **Kubernetes GPU recommended for:**
-
-- Containerized applications
-- Workloads requiring automatic scaling
-- Parallel and distributed jobs
-- GPU resource sharing
-- Complex ML/AI pipelines
+**Kubernetes GPU**: containerized workloads, autoscaling, parallel/distributed jobs, ML/AI pipelines.
 
 ---
 
-## 🔧 Advanced Configuration
+## ✅ Verification
 
-### **Multi-GPU on VM**
-
-```yaml
-apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
-metadata:
-  name: multi-gpu-vm
-spec:
-  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
-  gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-```
-
-### **Specialized GPU NodeGroup**
-
-```yaml
-nodeGroups:
-  gpu-inference:
-    minReplicas: 2
-    maxReplicas: 10
-    instanceType: "u1.large"
-    gpus:
-      - name: "nvidia.com/AD102GL_L40S"
-    
-  gpu-training:
-    minReplicas: 1
-    maxReplicas: 3
-    instanceType: "u1.4xlarge"
-    gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-```
-
-### **Pod with Specific GPU**
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: specific-gpu-pod
-spec:
-  nodeSelector:
-    gpu-type: "L40S"
-  containers:
-  - name: app
-    image: nvidia/cuda:12.0-runtime-ubuntu20.04
-    resources:
-      limits:
-        nvidia.com/gpu: 1
-```
-
----
-
-## ✅ Verification and Monitoring
-
-### **VM GPU Verification**
+### VM GPU
 
 ```bash
-# Access VM
 virtctl ssh ubuntu@vm-gpu
-
-# Check GPUs
 nvidia-smi
-
-# CUDA test
 nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
 ```
 
-### **Kubernetes GPU Verification**
+### Kubernetes GPU
 
 ```bash
-# See GPU resources on nodes
-kubectl describe nodes
-
-# Check GPU allocation
+# GPUs exposed on the nodes (requires gpuOperator active)
 kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.'nvidia\.com/gpu'
 
-# Monitor GPU usage
-kubectl top nodes
-```
-
-### **GPU Monitoring in a Pod**
-
-```bash
-# Exec into a pod with GPU
+# Check from a pod
 kubectl exec -it <pod-name> -- nvidia-smi
-
-# See GPU metrics
-kubectl exec -it <pod-name> -- nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv -l 5
 ```
 
 ---
 
 ## 💡 Best Practices
 
-### **For VM GPU:**
-
-- Use `replicated` storage class for production
-- Size CPU/RAM according to GPU (ratio 8-16 vCPU per GPU)
-- Install NVIDIA drivers via cloud-init
-- Stop VMs when unused to optimize costs
-
-### **For Kubernetes GPU:**
-
-- Configure appropriate resource limits
-- Use nodeSelector or nodeAffinity to target specific GPUs
-- Implement PodDisruptionBudgets for critical workloads
-- Monitor GPU usage with custom metrics
-
-### **General:**
-
-- L40S for inference/development
-- A100 for standard ML training  
-- H100 for LLM and exascale computing
-- Test with L40S before moving to more expensive GPUs
-
+- **L40S** for inference and development, **A100** for ML training, **RTX PRO 6000 (Blackwell)** for the most demanding workloads.
+- Test with an L40S before reserving the most expensive GPUs.
+- Size CPU/RAM according to the GPU (≈ 8–16 vCPU per GPU) and plan for ≥ 4 GiB of RAM.
+- On VM: install the NVIDIA drivers via cloud-init (see [Install CUDA drivers](../compute/how-to/install-cuda-drivers.md)).
+- On Kubernetes: always enable the `gpuOperator` addon.
+- Use the `replicated` `storageClass` in production.

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
@@ -15,7 +15,7 @@ graph TB
         subgraph "Physical GPUs"
             G1[NVIDIA L40S]
             G2[NVIDIA A100]
-            G3[NVIDIA H100]
+            G3[NVIDIA RTX PRO 6000<br/>Blackwell]
         end
 
         subgraph "VM Allocation"
@@ -58,19 +58,20 @@ graph TB
 
 ## Available GPU types
 
-| GPU | Architecture | Memory | Performance (INT8) | Use case |
-|-----|-------------|--------|-------------------|----------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS | Inference, development, prototyping |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS | ML training, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS | LLM, exascale computing, distributed training |
+| GPU | Architecture | Memory | Use case |
+|-----|-------------|--------|----------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inference, development, prototyping |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML training, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensive computing, distributed training |
 
 ### GPU identifiers in manifests
 
-| GPU | `gpus[].name` / `nvidia.com/` value |
-|-----|---------------------------------------|
+| GPU | `gpus[].name` value |
+|-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ---
 
@@ -93,8 +94,8 @@ Plan for **8 to 16 vCPU per GPU**. For a single GPU, a `u1.2xlarge` (8 vCPU, 32 
 
 GPUs are exposed to pods via the **NVIDIA Device Plugin**:
 
-- The GPU Operator must be enabled on the cluster (`plugins.gpu-operator.enabled: true`)
-- Pods request a GPU via `resources.limits` (e.g., `nvidia.com/AD102GL_L40S: 1`)
+- The GPU Operator must be enabled on the cluster (`addons.gpuOperator.enabled: true`)
+- Pods request a GPU via `resources.limits` (`nvidia.com/gpu: 1`)
 - The Kubernetes scheduler places the pod on a node that has the requested GPU
 - GPU nodes are configured in **node groups** with the `gpus[]` field
 
@@ -108,7 +109,7 @@ graph LR
 
     subgraph "Pod"
         C[Container]
-        RL[resources.limits:<br/>nvidia.com/AD102GL_L40S: 1]
+        RL[resources.limits:<br/>nvidia.com/gpu: 1]
     end
 
     GPU --> DP
@@ -136,8 +137,8 @@ graph LR
 |-----------|-------|
 | GPU per VM | Multiple (depending on availability) |
 | GPU per Kubernetes pod | Multiple (via `resources.limits`) |
-| GPU types | L40S, A100, H100 |
-| Max GPU memory | 80 GB (A100/H100) |
+| GPU types | L40S, A100 (PCIe/SXM4), RTX PRO 6000 Blackwell |
+| Max GPU memory | 96 GB (RTX PRO 6000 Blackwell) |
 
 ---
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/faq.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/faq.md
@@ -7,21 +7,22 @@ title: FAQ
 
 ### What GPU models are available?
 
-Hikube offers three NVIDIA GPU families:
+Hikube offers several NVIDIA GPUs:
 
 | GPU | Architecture | Memory | Use case |
 |-----|-------------|--------|----------|
 | **L40S** | Ada Lovelace | 48 GB GDDR6 | Inference, graphical rendering |
-| **A100** | Ampere | 80 GB HBM2e | ML training, scientific computing |
-| **H100** | Hopper | 80 GB HBM3 | LLM, exascale computing |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML training, scientific computing |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensive computing |
 
 Identifiers to use in manifests:
 
 ```yaml
 gpus:
-  - name: "nvidia.com/AD102GL_L40S"       # L40S
-  - name: "nvidia.com/GA100_A100_PCIE_80GB" # A100
-  - name: "nvidia.com/H100_94GB"           # H100
+  - name: "nvidia.com/AD102GL_L40S"                                  # L40S
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"                          # A100 PCIe
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"                          # A100 SXM4
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION" # RTX PRO 6000 Blackwell
 ```
 
 ---

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
@@ -4,7 +4,7 @@ title: "How to provision a GPU on Kubernetes"
 
 # How to provision a GPU on Kubernetes
 
-Hikube allows you to add NVIDIA GPU-equipped node groups to your Kubernetes clusters. This guide explains how to configure a cluster with GPU workers, deploy pods that leverage GPU acceleration, and set up specialized node groups.
+Hikube allows you to add node groups equipped with NVIDIA GPUs to your Kubernetes clusters. This guide explains how to configure a cluster with GPU workers, deploy pods that leverage GPU acceleration, and set up specialized node groups.
 
 ## Prerequisites
 
@@ -41,7 +41,16 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Required: installs the NVIDIA drivers and the device plugin
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning `gpuOperator` addon required
+Attaching GPUs to the node groups is not enough: without `addons.gpuOperator.enabled: true`, the NVIDIA drivers and the device plugin are not installed in the tenant cluster, and `nvidia.com/gpu` stays at 0 on the nodes.
+:::
 
 :::tip
 Separate your CPU and GPU workloads into distinct node groups. This allows independent scaling and better cost control.
@@ -170,6 +179,10 @@ spec:
       gpus:
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
+
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 To target a specific node group in your deployments, use `nodeSelector`:
@@ -202,7 +215,7 @@ spec:
 ```
 
 :::note
-The GPUs available for Kubernetes are the same as for VMs: **L40S** (inference/dev), **A100** (ML training), and **H100** (LLM/exascale). See the [GPU API reference](../api-reference.md) for full specifications.
+The GPUs available for Kubernetes are the same as for VMs: **L40S** (inference/dev), **A100 PCIe/SXM4** (ML training), and **RTX PRO 6000 Blackwell** (LLM/intensive computing). See the [GPU API reference](../api-reference.md) for the exact resource names and specifications.
 :::
 
 ## Verification

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
@@ -4,7 +4,7 @@ title: "How to provision a GPU on a VM"
 
 # How to provision a GPU on a VM
 
-Hikube allows you to attach one or more NVIDIA GPUs directly to a virtual machine. This guide explains how to choose the right GPU type for your workload, create a VM with GPU, and verify that hardware acceleration is available.
+Hikube allows you to attach one or more NVIDIA GPUs directly to a virtual machine. This guide explains how to choose the GPU type suited to your workload, create a VM with GPU, and verify that hardware acceleration is available.
 
 ## Prerequisites
 
@@ -16,31 +16,43 @@ Hikube allows you to attach one or more NVIDIA GPUs directly to a virtual machin
 
 ### 1. Choose the GPU type
 
-Hikube offers three NVIDIA GPU families suited to different use cases:
+Hikube offers several NVIDIA GPUs suited to different use cases:
 
-| GPU | Architecture | Memory | Performance | Use case |
-|-----|-------------|---------|-------------|----------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) | Inference, development, prototyping |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) | ML training, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) | LLM, exascale computing, distributed training |
+| GPU | Architecture | Memory | Use case |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inference, development, prototyping |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | ML training, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, intensive computing, distributed training |
 
 :::tip Which GPU to choose?
-Start with an **L40S** for development and prototyping. Move to an **A100** for standard ML model training, and reserve the **H100** for demanding workloads such as LLM training or high-performance computing.
+Start with an **L40S** for development and prototyping. Move to an **A100** for standard ML model training, and reserve the **RTX PRO 6000 (Blackwell)** for the most demanding workloads such as LLM training or high-performance computing.
 :::
 
 The GPU identifiers to use in your manifests are:
 
 | GPU | `gpus[].name` value |
-|-----|---------------------|
+|-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ### 2. Create the VM manifest with GPU
 
 Create a manifest that declares the desired GPU in the `spec.gpus` section:
 
 ```yaml title="gpu-vm.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: gpu-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 100Gi
+  storageClass: replicated
+---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -51,9 +63,8 @@ spec:
   instanceType: u1.2xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 100Gi
-    storageClass: replicated
+  disks:
+    - name: gpu-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -132,6 +143,17 @@ For intensive workloads (distributed training, large-scale inference), you can a
 
 ```yaml title="multi-gpu-vm.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: multi-gpu-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
   name: multi-gpu-workstation
@@ -140,13 +162,12 @@ spec:
   instanceProfile: ubuntu
   instanceType: u1.8xlarge
   gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+  disks:
+    - name: multi-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/overview.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/overview.md
@@ -39,28 +39,28 @@ GPUs can be allocated to Kubernetes workers and then assigned to pods via resour
 
 ## 🖥️ Available Hardware
 
-Hikube offers three types of NVIDIA GPUs:
+Hikube offers several NVIDIA GPUs:
 
 ### **NVIDIA L40S**
 
-- **Architecture** : Ada Lovelace
-- **Memory** : 48 GB GDDR6 with ECC
-- **Performance** : 362 TOPS (INT8), 91.6 TFLOPs (FP32)
-- **Typical usage** : Generative AI, inference, real-time rendering
+- **Architecture**: Ada Lovelace
+- **Memory**: 48 GB GDDR6 with ECC
+- **Resource name**: `nvidia.com/AD102GL_L40S`
+- **Typical usage**: Generative AI, inference, real-time rendering
 
-### **NVIDIA A100**
+### **NVIDIA A100 80 GB (PCIe / SXM4)**
 
-- **Architecture** : Ampere
-- **Memory** : 80 GB HBM2e with ECC
-- **Performance** : 312 TOPS (INT8), 624 TFLOPs (Tensor)
-- **Typical usage** : ML training, high-performance computing
+- **Architecture**: Ampere
+- **Memory**: 80 GB HBM2e with ECC
+- **Resource names**: `nvidia.com/GA100_A100_PCIE_80GB`, `nvidia.com/GA100_A100_SXM4_80GB`
+- **Typical usage**: ML training, high-performance computing (the SXM4 variant supports NVLink for multi-GPU)
 
-### **NVIDIA H100**
+### **NVIDIA RTX PRO 6000 Blackwell**
 
-- **Architecture** : Hopper
-- **Memory** : 80 GB HBM3 with ECC
-- **Performance** : 1979 TOPS (INT8), 989 TFLOPs (Tensor)
-- **Typical usage** : LLM, transformers, exascale computing
+- **Architecture**: Blackwell (Server Edition)
+- **Memory**: 96 GB GDDR7 with ECC
+- **Resource name**: `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`
+- **Typical usage**: LLM, transformers, intensive computing
 
 ---
 
@@ -74,7 +74,7 @@ flowchart TD
         subgraph NODE["Physical Node"]
             GPU1["🎮 GPU L40S"]
             GPU2["🎮 GPU A100"]
-            GPU3["🎮 GPU H100"]
+            GPU3["🎮 GPU RTX PRO 6000"]
         end
         
         subgraph VM1["VM Instance"]
@@ -131,11 +131,14 @@ flowchart TD
 
 ```yaml
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 spec:
+  runStrategy: Always
   instanceType: "u1.xlarge"
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
 ### **GPU on Kubernetes Worker**
@@ -149,6 +152,9 @@ spec:
       instanceType: "u1.xlarge"
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 ### **GPU in Kubernetes Pod**
@@ -201,4 +207,3 @@ spec:
     {label: "Compute Resources", href: "../../compute/"},
   ]}
 />
-

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
@@ -15,8 +15,8 @@ This guide presents the two methods of using GPUs: with virtual machines and wit
 
 Hikube offers two approaches for using GPUs:
 
-1. **GPU with VM** : Direct attachment of a GPU to a virtual machine
-2. **GPU with Kubernetes** : GPU allocation to workers for use by pods
+1. **GPU with VM**: Direct attachment of a GPU to a virtual machine
+2. **GPU with Kubernetes**: GPU allocation to workers for use by pods
 
 ---
 
@@ -42,18 +42,17 @@ spec:
 
 ```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu-example
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge  # 4 vCPU, 16 GB RAM
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 50Gi
-    storageClass: replicated
+  disks:
+    - name: ubuntu-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -89,7 +88,7 @@ kubectl apply -f vm-disk.yaml
 kubectl apply -f vm-gpu.yaml
 
 # Check status
-kubectl get virtualmachine vm-gpu-example
+kubectl get vminstance vm-gpu-example
 ```
 
 ### **Step 4: Access and test**
@@ -133,9 +132,19 @@ spec:
       maxReplicas: 2
       instanceType: "s1.medium"
       ephemeralStorage: 50Gi
-  
+
   storageClass: "replicated"
+
+  addons:
+    # Essential: installs the NVIDIA drivers and the device plugin
+    # that expose nvidia.com/gpu to the pods of the tenant cluster
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning `gpuOperator` addon required
+Without the `gpuOperator` addon enabled, the GPUs attached to the workers are **not** exposed to pods (`nvidia.com/gpu` stays at 0). It installs the NVIDIA drivers and the device plugin in the tenant cluster.
+:::
 
 ### **Step 2: Deploy the cluster**
 
@@ -211,13 +220,15 @@ kubectl exec -it gpu-test -- nvidia-smi
 gpus:
   - name: "nvidia.com/AD102GL_L40S"  # 48 GB GDDR6
 
-# For ML training
+# For ML training (A100, two variants depending on the hardware)
 gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e (PCIe)
+  # or
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"  # 80 GB HBM2e (SXM4)
 
 # For LLM/exascale computing
 gpus:
-  - name: "nvidia.com/H100_94GB"  # 80 GB HBM3
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"  # 96 GB GDDR7
 ```
 
 ---
@@ -246,6 +257,27 @@ kubectl top nodes
 
 ---
 
+## Cleanup
+
+### Delete a GPU VM
+
+```bash
+kubectl delete -f vm-gpu.yaml
+kubectl delete -f vm-disk.yaml
+```
+
+### Delete a GPU Kubernetes cluster
+
+```bash
+kubectl delete -f cluster-gpu.yaml
+```
+
+:::warning
+These actions delete the GPU resources and all associated data. These operations are **irreversible**.
+:::
+
+---
+
 ## 🚀 Next Steps
 
 ### **To deepen VM GPU:**
@@ -262,9 +294,9 @@ kubectl top nodes
 
 ## 💡 Tips
 
-- **VM GPU** : Ideal for prototyping and legacy applications
-- **Kubernetes GPU** : Recommended for scalable production workloads
-- Start with **L40S** to test before using A100/H100
+- **VM GPU**: Ideal for prototyping and legacy applications
+- **Kubernetes GPU**: Recommended for scalable production workloads
+- Start with **L40S** to test before using A100 or RTX PRO 6000 (Blackwell)
 - Use `replicated` storage class for production
 
 <NavigationFooter
@@ -276,4 +308,3 @@ kubectl top nodes
     {label: "Compute Resources", href: "../../compute/"},
   ]}
 />
-

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
@@ -1,208 +1,296 @@
 ---
-
 sidebar_position: 6
 title: API Reference
---------------------
+---
 
-# Complete Examples
+# API Reference – Kubernetes
 
-## **Production Cluster**
+This reference describes Hikube's **`Kubernetes`** API (`apps.cozystack.io/v1alpha1`), which provisions managed Kubernetes clusters (Kamaji control plane + KubeVirt workers). The fields below correspond to the schema actually exposed by the platform.
+
+```yaml title="cluster.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kubernetes
+metadata:
+  name: my-cluster
+spec:
+  version: v1.35
+  storageClass: replicated
+  controlPlane:
+    replicas: 2
+  nodeGroups:
+    md0:
+      minReplicas: 1
+      maxReplicas: 5
+      instanceType: u1.medium
+      ephemeralStorage: 20Gi
+      roles:
+        - ingress-nginx
+  addons:
+    ingressNginx:
+      enabled: true
+```
+
+---
+
+## Specification
+
+| Parameter       | Type      | Description                                                            | Default      |
+| --------------- | --------- | --------------------------------------------------------------------- | ------------ |
+| `version`       | `string`  | Kubernetes version (`major.minor`) — see [versions](#version)         | `v1.35`      |
+| `storageClass`  | `string`  | Storage class for persistent volumes                                  | `replicated` |
+| `host`          | `string`  | External hostname of the cluster. Defaults to `<cluster>.<tenant-host>` | `""`       |
+| `controlPlane`  | `object`  | Control plane configuration — see [Concepts](concepts.md#control-plane) | `{}`       |
+| `nodeGroups`    | `object`  | Map of worker groups — see [nodeGroups](#nodegroups)                   | see default  |
+| `addons`        | `object`  | Cluster add-ons — see [addons](#addons)                               | `{}`         |
+
+---
+
+## version
+
+`version` selects the Kubernetes minor version to deploy.
+
+| Supported values |
+| ---------------- |
+| `v1.35` (default), `v1.34`, `v1.33`, `v1.32`, `v1.31`, `v1.30` |
+
+```yaml
+spec:
+  version: v1.34
+```
+
+See the [Upgrade a cluster](how-to/upgrade-cluster.md) guide for version upgrades.
+
+---
+
+## nodeGroups
+
+`nodeGroups` is a **map** (`<name>: {…}`) describing the worker groups. Each group is autoscaled between `minReplicas` and `maxReplicas`.
+
+| Field              | Type            | Description                                                       | Default     |
+| ------------------ | --------------- | ----------------------------------------------------------------- | ----------- |
+| `minReplicas`      | `integer`       | Minimum number of nodes (0 = scale-to-zero possible)             | `0`         |
+| `maxReplicas`      | `integer`       | Maximum number of nodes                                          | `10`        |
+| `instanceType`     | `string`        | Node flavor (see [instance types](../compute/api-reference.md#instance-types)) | `u1.medium` |
+| `ephemeralStorage` | `int`/`string`  | Ephemeral storage size per node (e.g., `20Gi`)                   | `20Gi`      |
+| `resources`        | `object`        | Explicit `cpu` / `memory` override per node                      | `{}`        |
+| `gpus`             | `[]object`      | GPUs attached to the nodes (`gpus[].name`) — see [GPU with Kubernetes](../gpu/api-reference.md) | `[]` |
+| `roles`            | `[]string`      | Node roles (e.g., `ingress-nginx`)                               | `[]`        |
+
+:::note `ephemeralStorage` is a scalar
+Specify a size directly (`ephemeralStorage: 20Gi`), not an object `{size: …}`.
+:::
+
+```yaml
+spec:
+  nodeGroups:
+    workers:
+      minReplicas: 1
+      maxReplicas: 10
+      instanceType: u1.xlarge
+      ephemeralStorage: 50Gi
+      roles:
+        - ingress-nginx
+    gpu-workers:
+      minReplicas: 0
+      maxReplicas: 4
+      instanceType: u1.2xlarge
+      ephemeralStorage: 200Gi
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
+```
+
+See [Concepts → Node Groups](concepts.md#node-groups) for the details of each field.
+
+---
+
+## addons
+
+The `addons` block enables the add-ons installed in the tenant cluster. Most expose `enabled` and `valuesOverride` (Helm values override).
+
+| Addon                  | Fields                                          | Role                                                      |
+| ---------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `certManager`          | `enabled`, `valuesOverride`                     | Automatic TLS certificate management                      |
+| `ingressNginx`         | `enabled`, `exposeMethod`, `hosts`, `valuesOverride` | NGINX Ingress controller (see below)                 |
+| `fluxcd`               | `enabled`, `valuesOverride`                     | GitOps (Flux)                                             |
+| `gatewayAPI`           | `enabled`                                       | Gateway API support                                       |
+| `gpuOperator`          | `enabled`, `valuesOverride`                     | NVIDIA GPU Operator (**required** for GPU workers)        |
+| `monitoringAgents`     | `enabled`, `valuesOverride`                     | Monitoring/logging agents                                 |
+| `velero`               | `enabled`, `valuesOverride`                     | Backup / restore                                          |
+| `cilium`               | `valuesOverride`                                | Cilium CNI (always on, override only)                     |
+| `coredns`              | `valuesOverride`                                | CoreDNS (always on, override only)                        |
+| `verticalPodAutoscaler`| `valuesOverride`                                | Vertical Pod Autoscaler (always on)                       |
+
+:::note
+`cilium`, `coredns`, and `verticalPodAutoscaler` have no `enabled` field (core components) — only `valuesOverride` is usable. `gatewayAPI` exposes only `enabled`.
+:::
+
+### certManager / fluxcd / velero / monitoringAgents / gpuOperator
+
+```yaml
+spec:
+  addons:
+    certManager:
+      enabled: true
+    gpuOperator:
+      enabled: true     # required if any nodeGroups carry gpus
+    velero:
+      enabled: true
+    monitoringAgents:
+      enabled: true
+    fluxcd:
+      enabled: true
+```
+
+### ingressNginx
+
+| Field            | Type       | Description                                                                  | Default    |
+| ---------------- | ---------- | ---------------------------------------------------------------------------- | ---------- |
+| `enabled`        | `boolean`  | Enables the controller (requires nodes with the `ingress-nginx` role)        | `false`    |
+| `exposeMethod`   | `string`   | Exposure method: `Proxied` or `LoadBalancer`                                | `Proxied`  |
+| `hosts`          | `[]string` | Domains routed to this cluster when `exposeMethod: Proxied`                 | `[]`       |
+| `valuesOverride` | `object`   | Helm values override                                                         | `{}`       |
+
+```yaml
+spec:
+  addons:
+    ingressNginx:
+      enabled: true
+      exposeMethod: Proxied
+      hosts:
+        - app.example.com
+        - "*.services.example.com"
+```
+
+---
+
+## Complete Examples
+
+### Production cluster
 
 ```yaml title="production-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: production
-  namespace: company-prod
-  labels:
-    environment: production
-    criticality: high
-    team: platform
 spec:
-  # Cluster configuration
-  host: "k8s-prod.company.com"
-  storageClass: "replicated"
+  version: v1.34
+  storageClass: replicated
+  host: k8s-prod.example.com
 
-  # High-availability control plane
   controlPlane:
     replicas: 3
 
-  # Specialized node groups
   nodeGroups:
-    # General nodes with Ingress
     web:
       minReplicas: 3
       maxReplicas: 10
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Compute nodes for intensive workloads
     compute:
       minReplicas: 1
       maxReplicas: 5
-      instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
+      instanceType: u1.4xlarge
       ephemeralStorage: 100Gi
       roles: []
 
-    # Dedicated monitoring nodes
-    monitoring:
-      minReplicas: 2
-      maxReplicas: 4
-      instanceType: "m1.xlarge"   # 4 vCPU, 32 GB RAM
-      ephemeralStorage: 200Gi
-      roles:
-        - monitoring
-
-  # Complete add-ons
   addons:
-    # Automatic SSL certificates
     certManager:
       enabled: true
-      valuesOverride:
-        prometheus:
-          enabled: true
-
-    # HTTP/HTTPS exposure
     ingressNginx:
       enabled: true
+      exposeMethod: Proxied
       hosts:
-        - "app.company.com"
-        - "api.company.com"
-        - "*.services.company.com"
-      valuesOverride:
-        controller:
-          replicaCount: 3
-          resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
-
-    # GitOps for deployments
+        - app.example.com
+        - api.example.com
     fluxcd:
       enabled: true
-      valuesOverride:
-        gitRepository:
-          url: "https://github.com/company/k8s-production"
-          branch: "main"
-
-    # Full monitoring
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        fluentbit:
-          enabled: true
+    velero:
+      enabled: true
 ```
 
-## **Development Cluster**
+### Development cluster
 
 ```yaml title="development-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: development
-  namespace: company-dev
-  labels:
-    environment: development
-    auto-cleanup: "7d"
 spec:
-  # Basic configuration
-  host: "k8s-dev.company.local"
-  storageClass: "replicated"
+  storageClass: replicated
 
-  # Minimal control plane
   controlPlane:
-    replicas: 1  # Resource saving
+    replicas: 1   # resource saving (no HA)
 
-  # Single multipurpose node group
   nodeGroups:
     general:
       minReplicas: 1
       maxReplicas: 3
-      instanceType: "s1.medium"
+      instanceType: s1.medium
       ephemeralStorage: 30Gi
       roles:
         - ingress-nginx
 
-  # Essential add-ons only
   addons:
     certManager:
       enabled: true
-
     ingressNginx:
       enabled: true
       hosts:
-        - "*.dev.company.local"
-      valuesOverride:
-        controller:
-          replicaCount: 1  # Minimal replication
+        - "*.dev.example.com"
 ```
 
-## **ML/AI Cluster with GPU**
+### ML/AI cluster with GPU
 
 ```yaml title="ml-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: machine-learning
-  namespace: company-ai
-  labels:
-    environment: ai
-    workload: gpu
 spec:
-  host: "k8s-ai.company.com"
-  storageClass: "fast-ssd"  # High-performance storage
+  storageClass: replicated
 
   controlPlane:
     replicas: 2
 
   nodeGroups:
-    # Standard nodes for orchestration
     system:
       minReplicas: 2
       maxReplicas: 4
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # GPU nodes for ML workloads
     gpu:
-      minReplicas: 0      # Zero-scaling allowed
+      minReplicas: 0          # scale-to-zero when idle
       maxReplicas: 10
-      instanceType: "u1.2xlarge"
-      gpus: # Instance with GPU
-        - name: nvidia.com/AD102GL_L40S # Nvidia L40S
-      ephemeralStorage: 500Gi      # Large storage for datasets
+      instanceType: u1.2xlarge
+      ephemeralStorage: 500Gi # datasets
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
       roles: []
 
   addons:
     certManager:
       enabled: true
-
+    # Required to expose GPUs to pods (nvidia.com/gpu)
+    gpuOperator:
+      enabled: true
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        # GPU-specific monitoring
-        dcgmExporter:
-          enabled: true
 ```
 
----
+:::tip Best practices
+- `controlPlane.replicas: 3` in production (etcd quorum / HA).
+- Separate workloads into dedicated node groups (web, compute, GPU).
+- For GPUs: a node group with `gpus` **and** `addons.gpuOperator.enabled: true`.
+- Enable monitoring and backups (Velero) on critical clusters.
+:::
 
-:::tip 💡 Best Practices
-
-* **Use labels** to organize clusters by environment
-* **Configure RBAC** from the start to secure access
-* **Enable monitoring** for full observability
-* **Plan capacity** using appropriate node groups
-* **Test backups** regularly
-  :::
-
-:::warning ⚠️ Warning
-
-* **Deletions are irreversible** — ensure backups exist
-* **Updates** may impact workloads
-* **Check compatibility** of add-ons with Kubernetes versions
-  :::
+:::warning Warning
+- Cluster deletions are **irreversible** — check your backups.
+- Without the `gpuOperator` addon, GPUs attached to workers are not exposed to pods.
+:::

--- a/i18n/en/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
@@ -38,7 +38,7 @@ The diagram below illustrates the structure and main interactions of the **Hikub
 - Each group contains multiple **worker nodes**.
 - Workloads (pods) are deployed on these nodes.
 - Nodes communicate with the Control Plane to receive their tasks.
-- They read and write their data to **Kubernetes Persistent Volumes (PV)**.
+- They read and write their data to the Kubernetes **Persistent Volumes (PV)**.
 
 #### Kubernetes PV Data
 
@@ -55,7 +55,7 @@ The diagram below illustrates the structure and main interactions of the **Hikub
 - Serves as an interface between Kubernetes and the **regional storage systems**.
 - Automatically replicates PV data to multiple regions for:
   - **high availability**,
-  - **regional failure resilience**,
+  - **resilience to regional failures**,
   - and **service continuity**.
 
 #### Regional storage
@@ -73,7 +73,7 @@ Each region has its own storage backend, all synchronized through the Hikube lay
 1. **Etcd nodes** synchronize with each other to maintain a consistent global state.
 2. The **Control Plane** reads/writes to etcd to store the cluster state.
 3. The **Control Plane** schedules workloads on the **Node Groups**.
-4. The **Node Groups** interact with **Kubernetes PVs** to store or retrieve data.
+4. The **Node Groups** interact with the **Kubernetes PVs** to store or retrieve data.
 5. **PV Data** is replicated through the **Hikube Replication Data Layer** to the **3 regions**.
 
 ---
@@ -216,13 +216,12 @@ The `nodeGroup` field defines the configuration of a node group (workers) within
 It allows specifying the instance type, resources, number of replicas, as well as roles and associated GPUs.
 
 ```yaml title="node-group.yaml"
-nodeGroup:
+nodeGroups:
   <name>:
-    ephemeralStorage:
-      size: 100Gi
+    ephemeralStorage: 100Gi
     gpus:
       - name: nvidia.com/AD102GL_L40S
-    instanceType: m5.large
+    instanceType: u1.xlarge
     maxReplicas: 5
     minReplicas: 2
     resources:
@@ -234,10 +233,10 @@ nodeGroup:
 
 ---
 
-### `ephemeralStorage` (Object)
+### `ephemeralStorage` (string)
 
-Defines the **ephemeral storage** configuration associated with the group's nodes.
-This storage is used for temporary data, caches, or log files.
+Defines the size of the **ephemeral storage** per node in the group (e.g., `100Gi`).
+This storage is used for temporary data, caches, or log files. It is a scalar value (not an object `{size: …}`).
 
 ### `gpus` (Array)
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/tools/terraform.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tools/terraform.md
@@ -80,22 +80,32 @@ resource "kubectl_manifest" "kubernetes_cluster" {
       namespace = "default"
     }
     spec = {
+      version      = "v1.34"
+      storageClass = "replicated"
+
       controlPlane = {
         replicas = 2
       }
-      
+
       nodeGroups = {
         general = {
           minReplicas      = 1
           maxReplicas      = 5
           instanceType     = "s1.large"
           ephemeralStorage = "50Gi"
-          roles = ["ingress-nginx"]
+          roles            = ["ingress-nginx"]
         }
+        # Example GPU node group (requires the gpuOperator addon below)
+        # gpu = {
+        #   minReplicas      = 0
+        #   maxReplicas      = 4
+        #   instanceType     = "u1.2xlarge"
+        #   ephemeralStorage = "200Gi"
+        #   gpus             = [{ name = "nvidia.com/AD102GL_L40S" }]
+        #   roles            = []
+        # }
       }
-      
-      storageClass = "replicated"
-      
+
       addons = {
         certManager = {
           enabled = true
@@ -106,12 +116,16 @@ resource "kubectl_manifest" "kubernetes_cluster" {
             "${var.cluster_name}.example.com"
           ]
         }
+        # Required to expose GPUs to the pods of a GPU node group
+        # gpuOperator = {
+        #   enabled = true
+        # }
       }
     }
   })
 }
 
-# Retrieve kubeconfig
+# Retrieve the kubeconfig
 data "kubernetes_secret" "cluster_kubeconfig" {
   depends_on = [kubectl_manifest.kubernetes_cluster]
   
@@ -121,7 +135,7 @@ data "kubernetes_secret" "cluster_kubeconfig" {
   }
 }
 
-# Save kubeconfig
+# Save the kubeconfig
 resource "local_file" "kubeconfig" {
   content = base64decode(
     data.kubernetes_secret.cluster_kubeconfig.data["super-admin.conf"]
@@ -134,29 +148,52 @@ resource "local_file" "kubeconfig" {
 ### Deploy a Virtual Machine
 
 ```hcl title="virtual-machine.tf"
-resource "kubectl_manifest" "virtual_machine" {
+# The disk is a separate VMDisk resource, referenced by the VM
+resource "kubectl_manifest" "vm_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "${var.vm_name}-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "50Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "virtual_machine" {
+  depends_on = [kubectl_manifest.vm_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = var.vm_name
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
-      
-      systemDisk = {
-        size         = "50Gi"
-        storageClass = "replicated"
-      }
-      
+
+      disks = [
+        {
+          name = "${var.vm_name}-disk"
+        }
+      ]
+
       external       = true
       externalMethod = "PortList"
       externalPorts  = [22, 80, 443]
-      
+
       sshKeys = [var.ssh_public_key]
-      
+
       cloudInit = <<-EOT
         #cloud-config
         users:
@@ -186,35 +223,59 @@ resource "kubectl_manifest" "virtual_machine" {
 ### Deploy a VM with GPU
 
 ```hcl title="vm-gpu.tf"
-resource "kubectl_manifest" "vm_gpu" {
+resource "kubectl_manifest" "vm_gpu_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "gpu-vm-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "100Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "vm_gpu" {
+  depends_on = [kubectl_manifest.vm_gpu_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = "gpu-vm"
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
-      
+
       gpus = [
         {
+          # Models: nvidia.com/AD102GL_L40S, nvidia.com/GA100_A100_PCIE_80GB,
+          # nvidia.com/GA100_A100_SXM4_80GB, nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION
           name = "nvidia.com/AD102GL_L40S"
         }
       ]
-      
-      systemDisk = {
-        size         = "100Gi"
-        storageClass = "replicated"
-      }
-      
+
+      disks = [
+        {
+          name = "gpu-vm-disk"
+        }
+      ]
+
       external       = true
       externalMethod = "PortList"
       externalPorts  = [22, 8888]
-      
+
       sshKeys = [var.ssh_public_key]
-      
+
       cloudInit = <<-EOT
         #cloud-config
         users:
@@ -295,7 +356,7 @@ output "cluster_kubeconfig" {
 
 output "vm_status" {
   description = "Command to check VM status"
-  value       = "kubectl get virtualmachine ${var.vm_name}"
+  value       = "kubectl get vminstance ${var.vm_name}"
 }
 
 output "postgres_connection" {
@@ -366,4 +427,3 @@ terraform destroy
 - [Kubernetes Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs)
 - [kubectl Provider](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs)
 - [Terraform Documentation](https://developer.hashicorp.com/terraform/docs)
-

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/compute/api-reference.md
@@ -5,7 +5,9 @@ title: Riferimento API
 
 ## Riferimento API – Macchine Virtuali
 
-Questo riferimento descrive in modo esaustivo le API **VMInstance** e **VMDisk** di Hikube: parametri disponibili, esempi di utilizzo e buone pratiche raccomandate.
+Questo riferimento descrive in modo esaustivo le API **VMInstance** e **VMDisk** di Hikube: parametri disponibili, valori predefiniti, esempi di utilizzo e buone pratiche raccomandate.
+
+I campi documentati qui sotto corrispondono allo schema realmente esposto dalla piattaforma (`apps.cozystack.io/v1alpha1`).
 
 ---
 
@@ -13,9 +15,9 @@ Questo riferimento descrive in modo esaustivo le API **VMInstance** e **VMDisk**
 
 ### Panoramica
 
-L'API `VMInstance` permette di creare, configurare e gestire macchine virtuali in Hikube.
+L'API `VMInstance` permette di creare, configurare e gestire macchine virtuali in Hikube. Una VM si basa su uno o più dischi descritti separatamente tramite la risorsa [`VMDisk`](#vmdisk).
 
-```yaml
+```yaml title="vm-instance.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -24,24 +26,60 @@ spec:
   # Configurazione dettagliata qui sotto
 ```
 
+:::warning Kind corretto
+La risorsa si chiama **`VMInstance`** (e non `VirtualMachine`). Il disco **non** è un campo `systemDisk` integrato: occorre creare una risorsa `VMDisk` distinta e referenziarla in `disks`.
+:::
+
 ---
 
 ### Specifica completa
 
-#### Parametri generali
+| Parametro         | Tipo             | Descrizione                                                                 | Default      | Richiesto |
+| ----------------- | ---------------- | --------------------------------------------------------------------------- | ------------ | ------ |
+| `external`        | `boolean`        | Attiva l'esposizione di rete dall'esterno del cluster                       | `false`      | no    |
+| `externalMethod`  | `string`         | Metodo di esposizione: `PortList` o `WholeIP`                              | `PortList`   | no    |
+| `externalPorts`   | `[]integer`      | Porte da inoltrare dall'esterno (usato con `PortList`)                     | `[22]`       | no    |
+| `runStrategy`     | `string`         | Stato di esecuzione desiderato (vedi [runStrategy](#runstrategy))           | `Always`     | no    |
+| `instanceType`    | `string`         | Modello CPU / memoria (vedi [tipi di istanze](#tipi-di-istanze))            | `u1.medium`  | no    |
+| `instanceProfile` | `string`         | Profilo OS / preferenze (driver, kernel) — vedi [profili](#profili-os)      | `ubuntu`     | no    |
+| `disks`           | `[]object`       | Lista dei `VMDisk` da collegare (vedi [disks](#dischi))                      | `[]`         | no    |
+| `subnets`         | `[]object`       | Sottoreti aggiuntive (VPC) — vedi [subnets](#sottoreti)                     | `[]`         | no    |
+| `gpus`            | `[]object`       | GPU da collegare in passthrough (vedi [gpus](#gpu))                          | `[]`         | no    |
+| `resources`       | `object`         | Override esplicito CPU / memoria / socket (vedi [resources](#risorse))      | `{}`         | no    |
+| `cpuModel`        | `string`         | Modello di CPU esposto alla VM (es.: `host-passthrough`)                     | `""`         | no    |
+| `sshKeys`         | `[]string`       | Chiavi SSH pubbliche iniettate                                              | `[]`         | no    |
+| `cloudInit`       | `string`         | Configurazione cloud-init (user-data YAML)                                   | `""`         | no    |
+| `cloudInitSeed`   | `string`         | Seed usato per generare un UUID SMBIOS stabile                              | `""`         | no    |
 
-| Parametro         | Tipo       | Descrizione                                  | Default    | Richiesto |
-| ----------------- | ---------- | -------------------------------------------- | ---------- | ------ |
-| `external`        | `boolean`  | Attiva l'esposizione di rete esterna della VM  | `false`    | ✅      |
-| `externalMethod`  | `string`   | Metodo di esposizione (`PortList`, `WholeIP`) | `PortList` | ✅      |
-| `externalPorts`   | `[]int`    | Porte esposte verso l'esterno               | `[]`       | ✅      |
-| `running`         | `boolean`  | Stato desiderato della VM                       | `true`     | ✅      |
-| `instanceType`    | `string`   | Modello CPU / memoria                        | –          | ✅      |
-| `instanceProfile` | `string`   | Profilo OS della VM                           | –          | ✅      |
-| `disks`           | `[]string` | Lista dei `VMDisk` collegati                  | `[]`       | ✅      |
-| `sshKeys`         | `[]string` | Chiavi SSH pubbliche iniettate                 | `[]`       | ✅      |
-| `cloudInit`       | `string`   | Configurazione cloud-init (YAML)              | `""`       | ✅      |
-| `cloudInitSeed`   | `string`   | Dati seed cloud-init                      | `""`       | ✅      |
+:::note
+Tutti i campi sono opzionali: una VM minimale richiede solo un disco avviabile referenziato in `disks`. I valori predefiniti qui sopra sono quelli applicati dalla piattaforma.
+:::
+
+---
+
+### runStrategy
+
+`runStrategy` controlla lo stato di esecuzione della VM. Sostituisce il vecchio campo booleano `running`.
+
+| Valore            | Comportamento                                                            |
+| ----------------- | ----------------------------------------------------------------------- |
+| `Always`          | La VM è mantenuta avviata (si riavvia automaticamente se si arresta)      |
+| `Halted`          | La VM è arrestata                                                        |
+| `Manual`          | Lo stato è gestito manualmente (`virtctl start` / `stop`)                |
+| `RerunOnFailure`  | Si riavvia solo dopo un errore                                           |
+| `Once`            | Si avvia una sola volta, senza riavvio automatico                        |
+
+```yaml
+spec:
+  runStrategy: Always
+```
+
+Per arrestare/riavviare una VM esistente:
+
+```bash
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Halted"}}'
+kubectl patch vminstance my-vm --type='merge' -p '{"spec":{"runStrategy":"Always"}}'
+```
 
 ---
 
@@ -57,29 +95,22 @@ spec:
     - 443
 ```
 
+Vedi [Metodi di esposizione di rete](#metodi-di-esposizione-di-rete).
+
 ---
 
 ### Tipi di istanze
 
-#### Serie S – Standard (rapporto 1:2)
+`instanceType` referenzia un `VirtualMachineClusterInstancetype`. Hikube espone diverse serie, ciascuna con le taglie `nano` → `8xlarge`:
 
-Workload generali, CPU condivisi e burstable.
-
-```yaml
-instanceType: s1.small     # 1 vCPU, 2 GB RAM
-instanceType: s1.medium    # 2 vCPU, 4 GB RAM
-instanceType: s1.large     # 4 vCPU, 8 GB RAM
-instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
-instanceType: s1.3large    # 12 vCPU, 24 GB RAM
-instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
-instanceType: s1.3xlarge   # 24 vCPU, 48 GB RAM
-instanceType: s1.4xlarge   # 32 vCPU, 64 GB RAM
-instanceType: s1.8xlarge   # 64 vCPU, 128 GB RAM
-```
-
-#### Serie U – Universal (rapporto 1:4)
+| Serie | Utilizzo                                                              |
+| ----- | --------------------------------------------------------------------- |
+| `s1`  | **Standard** — CPU condivise/burstable, rapporto vCPU:RAM 1:2         |
+| `u1`  | **Universal** — uso generale, rapporto 1:4 (predefinito)             |
+| `m1`  | **Memory optimized** — rapporto 1:8                                   |
 
 ```yaml
+# Esempi della serie Universal (rapporto 1:4)
 instanceType: u1.medium    # 1 vCPU, 4 GB RAM
 instanceType: u1.large     # 2 vCPU, 8 GB RAM
 instanceType: u1.xlarge    # 4 vCPU, 16 GB RAM
@@ -88,9 +119,17 @@ instanceType: u1.4xlarge   # 16 vCPU, 64 GB RAM
 instanceType: u1.8xlarge   # 32 vCPU, 128 GB RAM
 ```
 
-#### Serie M – Memory Optimized (rapporto 1:8)
+```yaml
+# Serie Standard (rapporto 1:2)
+instanceType: s1.small     # 1 vCPU, 2 GB RAM
+instanceType: s1.medium    # 2 vCPU, 4 GB RAM
+instanceType: s1.large     # 4 vCPU, 8 GB RAM
+instanceType: s1.xlarge    # 8 vCPU, 16 GB RAM
+instanceType: s1.2xlarge   # 16 vCPU, 32 GB RAM
+```
 
 ```yaml
+# Serie Memory optimized (rapporto 1:8)
 instanceType: m1.large     # 2 vCPU, 16 GB RAM
 instanceType: m1.xlarge    # 4 vCPU, 32 GB RAM
 instanceType: m1.2xlarge   # 8 vCPU, 64 GB RAM
@@ -98,19 +137,110 @@ instanceType: m1.4xlarge   # 16 vCPU, 128 GB RAM
 instanceType: m1.8xlarge   # 32 vCPU, 256 GB RAM
 ```
 
+:::tip GPU e `instanceType`
+Per collegare una GPU, scegliete una serie generalista (`u1`, `s1`…) e dichiarate la GPU tramite il campo [`gpus`](#gpu). Il driver NVIDIA richiede **almeno 4 GiB di RAM**.
+:::
+
 ---
 
-### Profili OS supportati
+### Profili OS
 
-I profili seguenti sono disponibili per configurare il sistema operativo della VM:
+`instanceProfile` carica le **preferenze KubeVirt** (driver, modello di macchina, kernel) adattate all'OS. **Non** definisce l'immagine — questa è gestita dal `VMDisk`. È soprattutto determinante per Windows (driver virtio).
 
-| Profilo | Descrizione |
-|--------|-------------|
-| `ubuntu` | Ubuntu Server (raccomandato) |
-| `centos` | CentOS Stream |
-| `debian` | Debian |
-| `fedora` | Fedora Server |
-| `windows` | Windows Server |
+Valori disponibili (estratto):
+
+| Famiglia    | Profili                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| Ubuntu      | `ubuntu`                                                                                 |
+| RHEL        | `rhel.7`, `rhel.8`, `rhel.9`, `rhel.10` (+ varianti `.desktop`, `.arm64`, `.dpdk`, `.realtime`) |
+| CentOS      | `centos.7`, `centos.stream8`, `centos.stream9`, `centos.stream10` (+ `.desktop`, `.dpdk`) |
+| Fedora      | `fedora`, `fedora.arm64`                                                                  |
+| openSUSE    | `opensuse.leap`, `opensuse.tumbleweed`                                                    |
+| SLES        | `sles`                                                                                    |
+| Altri       | `alpine`, `cirros`                                                                        |
+| Windows     | `windows.2k22.virtio`, `windows.2k25.virtio`, `windows.10.virtio`, `windows.11.virtio` (varianti `.virtio` **raccomandate**); anche le varianti senza virtio sono disponibili (`windows.2k22`…) |
+
+:::note
+**Non** esiste un profilo `debian` né `rocky`/`almalinux` dedicato. Per queste distribuzioni, usate `ubuntu` (base Debian) o lasciate `instanceProfile: ""`. Per Windows, usate sempre una variante `.virtio` (es.: `windows.2k25.virtio`) per caricare i driver virtio.
+:::
+
+---
+
+### Dischi
+
+`disks` è una **lista di oggetti** che referenzia risorse [`VMDisk`](#vmdisk) tramite il loro nome. Il primo disco elencato è generalmente il disco avviabile.
+
+| Campo           | Tipo     | Descrizione                                          |
+| --------------- | -------- | ---------------------------------------------------- |
+| `disks[].name`  | `string` | Nome del `VMDisk` da collegare                       |
+| `disks[].bus`   | `string` | Tipo di bus (`virtio`, `sata`, `scsi`) — opzionale  |
+
+```yaml
+spec:
+  disks:
+    - name: vm-system-disk
+    - name: vm-data-disk
+      bus: scsi
+```
+
+:::warning
+La VM non prende in considerazione un nuovo disco finché non viene riavviata (`virtctl restart` o cambio di `runStrategy`).
+:::
+
+---
+
+### GPU
+
+`gpus` collega una o più GPU NVIDIA in passthrough PCI.
+
+| Campo          | Tipo     | Descrizione                                |
+| -------------- | -------- | ------------------------------------------ |
+| `gpus[].name`  | `string` | Nome della risorsa GPU (`nvidia.com/...`)  |
+
+```yaml
+spec:
+  instanceType: u1.2xlarge
+  gpus:
+    - name: nvidia.com/AD102GL_L40S
+```
+
+I modelli disponibili su Hikube sono dettagliati nel [riferimento API GPU](../gpu/api-reference.md). Una GPU è assegnata in modo **esclusivo** a una VM.
+
+---
+
+### Sottoreti
+
+`subnets` collega la VM a sottoreti aggiuntive di un VPC.
+
+| Campo             | Tipo     | Descrizione           |
+| ----------------- | -------- | --------------------- |
+| `subnets[].name`  | `string` | Nome della sottorete  |
+
+```yaml
+spec:
+  subnets:
+    - name: subnet-ab2c3e47
+```
+
+---
+
+### Risorse
+
+Per impostazione predefinita, il dimensionamento CPU/memoria è gestito da `instanceType`. Il blocco `resources` permette di **sovrascrivere** esplicitamente questi valori (e di definire una topologia di socket).
+
+| Campo                | Tipo            | Descrizione                          |
+| -------------------- | --------------- | ------------------------------------ |
+| `resources.cpu`      | `int`/`string`  | Numero di core CPU allocati          |
+| `resources.memory`   | `int`/`string`  | Quantità di memoria allocata         |
+| `resources.sockets`  | `int`/`string`  | Numero di socket CPU (topologia)     |
+
+```yaml
+spec:
+  resources:
+    cpu: "4"
+    memory: 8Gi
+    sockets: "2"
+```
 
 ---
 
@@ -136,11 +266,11 @@ spec:
         sudo: ALL=(ALL) NOPASSWD:ALL
         ssh_authorized_keys:
           - ssh-rsa AAAA...
-
     packages:
       - htop
       - docker.io
-      - curl
+  # Seed opzionale per fissare l'UUID SMBIOS (licenze, identità macchina)
+  cloudInitSeed: ""
 ```
 
 ---
@@ -157,11 +287,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.2xlarge
   instanceProfile: ubuntu
   disks:
-    - vm-system-disk
+    - name: vm-system-disk
   sshKeys:
     - ssh-rsa AAAA...
 ```
@@ -172,33 +302,30 @@ spec:
 
 ### Panoramica
 
-L'API `VMDisk` permette di gestire i dischi virtuali associati alle VM.
-Supporta **diverse sorgenti di immagini**: HTTP, disco vuoto e **Golden Image**.
+L'API `VMDisk` gestisce i dischi virtuali collegati alle VM. Supporta diverse sorgenti di immagine: **HTTP**, **Golden Image** precaricata, oppure disco vuoto.
 
-```yaml
+```yaml title="disk-example.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMDisk
 metadata:
   name: disk-example
 spec:
   source:
-    http:
-      url: https://...
+    image:
+      name: ubuntu-2404
   optical: false
   storage: 30Gi
   storageClass: replicated
 ```
 
----
-
 ### Parametri principali
 
-| Parametro      | Tipo      | Descrizione              | Default      | Richiesto |
-| -------------- | --------- | ------------------------ | ------------ | ------ |
-| `source`       | `object`  | Sorgente dell'immagine disco | `{}`         | ✅      |
-| `optical`      | `boolean` | Disco ottico (ISO)     | `false`      | ✅      |
-| `storage`      | `string`  | Dimensione del disco         | –            | ✅      |
-| `storageClass` | `string`  | Classe di storage       | `replicated` | ✅      |
+| Parametro      | Tipo            | Descrizione                                  | Default      | Richiesto |
+| -------------- | --------------- | -------------------------------------------- | ------------ | ------ |
+| `storage`      | `int`/`string`  | Dimensione del disco                         | `5Gi`        | ✅     |
+| `storageClass` | `string`        | Classe di storage                            | `replicated` | ✅     |
+| `source`       | `object`        | Sorgente dell'immagine disco (vedi sotto)    | `{}`         | no    |
+| `optical`      | `boolean`       | Disco ottico / ISO (installer)               | `false`      | no    |
 
 ---
 
@@ -213,28 +340,9 @@ spec:
       url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 ```
 
----
+### Golden Image (immagini precaricate Hikube)
 
-### Disco vuoto
-
-```yaml
-spec:
-  source: {}
-```
-
----
-
-### Golden Image (Immagini precaricate Hikube)
-
-Le **Golden Image** sono immagini di sistema mantenute e precaricate in Hikube.
-Permettono un **provisioning rapido**, standardizzato e senza dipendenze esterne.
-
-:::tip Convenzione di denominazione
-Le immagini seguono il formato `{os}-{version}` (es.: `ubuntu-2404`, `rocky-9`).
-Specificate sempre la versione per garantire la compatibilità dei vostri workload.
-:::
-
-#### Utilizzo
+Le **Golden Image** sono immagini di sistema mantenute e precaricate in Hikube, per un provisioning rapido e senza dipendenze esterne.
 
 ```yaml
 spec:
@@ -267,20 +375,28 @@ spec:
 | `opensuse-160` | openSUSE Leap 16.0 | Cloud | 2 Gi |
 | `cloudlinux-8` | CloudLinux 8 | Cloud | 8 Gi |
 | `cloudlinux-9` | CloudLinux 9 | Cloud | 9 Gi |
+| `windows-server-2022` | Windows Server 2022 | ISO | 28 Gi |
+| `windows-server-2025` | Windows Server 2025 | ISO | 28 Gi |
 | `proxmox-8` | Proxmox VE 8 | ISO | 2 Gi |
 | `proxmox-9` | Proxmox VE 9 | ISO | 2 Gi |
 | `talos-112` | Talos Linux 1.12 | Cloud | 8 Gi |
 
 :::warning Immagini ISO
-Le immagini di tipo **ISO** (Proxmox) sono installer, non immagini cloud pronte all'uso.
-Richiedono un'installazione manuale tramite la console VNC.
+Le immagini di tipo **ISO** (Windows, Proxmox) sono installer e non immagini cloud pronte all'uso. Prevedete un'installazione iniziale tramite la console VNC. Per Windows, vedi la guida [Installare una VM Windows](how-to/install-windows-vm.md).
 :::
+
+### Disco vuoto
+
+```yaml
+spec:
+  source: {}
+```
+
+Un disco vuoto è utile per i volumi di dati aggiuntivi.
 
 ---
 
-### Esempi VMDisk
-
-#### Disco di sistema tramite Golden Image
+### Esempio VMDisk tramite Golden Image
 
 ```yaml title="ubuntu-golden-disk.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
@@ -300,10 +416,22 @@ spec:
 
 ## Classi di storage
 
-| Classe       | Descrizione         | Replica |
-| ------------ | ------------------- | ----------- |
-| `local`      | Storage locale nodo | ❌           |
-| `replicated` | Storage replicato   | ✅           |
+Hikube espone diverse `storageClass` basate su LINSTOR. Per una VM, `replicated` è raccomandata.
+
+| Classe                                 | Replica     | Cifratura   | Note                                             |
+| -------------------------------------- | :---------: | :---------: | ------------------------------------------------ |
+| `local`                                | ❌          | ❌          | Storage locale al nodo (predefinito), non resiliente |
+| `local-encrypted`                      | ❌          | ✅ (LUKS)   | Locale + cifrato                                 |
+| `replicated`                           | ✅          | ❌          | Replica sincrona — **raccomandato** per le VM    |
+| `replicated-encrypted`                 | ✅          | ✅ (LUKS)   | Replicato + cifrato                              |
+| `replicated-async`                     | ✅ (async)  | ❌          | Replica asincrona                                |
+| `replicated-async-encrypted`           | ✅ (async)  | ✅ (LUKS)   | Replica asincrona + cifrato                      |
+| `replicated-async-windows`             | ✅ (async)  | ❌          | Variante adatta ai dischi Windows                |
+| `replicated-async-windows-encrypted`   | ✅ (async)  | ✅ (LUKS)   | Variante Windows + cifrato                       |
+
+:::note
+Le varianti `-windows` sono ottimizzate per i dischi delle VM Windows. La cifratura (`-encrypted`) si basa su LUKS a livello di volume.
+:::
 
 ---
 
@@ -312,18 +440,17 @@ spec:
 ### PortList
 
 * Firewall automatico
-* Porte esplicitamente autorizzate
+* Solo le porte elencate in `externalPorts` sono accessibili
 * **Raccomandato in produzione**
 
 ### WholeIP
 
-* Tutte le porte esposte
-* Nessun filtraggio di rete
-* Solo per sviluppo
+* Un IP pubblico dedicato, tutte le porte esposte
+* Nessun filtraggio di rete lato piattaforma
+* Riservare allo sviluppo o ai gateway controllati
 
 :::warning Sicurezza
-Con `WholeIP`, la VM è interamente esposta su Internet.
-Un firewall OS è indispensabile.
+Con `WholeIP`, la VM è interamente esposta su Internet. Un firewall OS è indispensabile.
 :::
 
 ---
@@ -332,18 +459,18 @@ Un firewall OS è indispensabile.
 
 ### Sicurezza
 
-* Solo chiavi SSH
-* Firewall OS attivo
+* Autenticazione solo tramite chiavi SSH
+* Firewall OS attivo, `PortList` piuttosto che `WholeIP`
 
-### Archiviazione
+### Storage
 
-* `replicated` in produzione
-* Dischi separati sistema / dati
+* `replicated` (o varianti cifrate/Windows) in produzione
+* Separare disco di sistema e dischi di dati
 
 ### Prestazioni
 
-* Adattare il tipo di istanza al workload
-* Monitorare l'utilizzo reale
+* Adattare `instanceType` al workload, oppure sovrascrivere tramite `resources`
+* Per le GPU, prevedere ≥ 4 GiB di RAM e un rapporto CPU/RAM adeguato
 
 :::tip Architettura raccomandata
 In produzione, utilizzate come minimo **2 dischi** (sistema + dati) con storage replicato.

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/compute/faq.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/compute/faq.md
@@ -68,7 +68,7 @@ kind: VMDisk
 metadata:
   name: data-volume
 spec:
-  size: 100Gi
+  storage: 100Gi
   storageClass: replicated
 ```
 
@@ -81,7 +81,7 @@ spec:
   instanceType: u1.large
   instanceProfile: ubuntu
   disks:
-    - data-volume
+    - name: data-volume
 ```
 
 ---
@@ -149,7 +149,7 @@ Cloud-init viene eseguito al primo avvio della VM e permette di installare pacch
 
 | Parametro | Ruolo | Esempi |
 |-----------|------|----------|
-| `instanceProfile` | Carica i **driver e i kernel** adatti all'OS | `ubuntu`, `centos`, `windows.2k25.virtio` |
+| `instanceProfile` | Carica i **driver e i kernel** adatti all'OS | `ubuntu`, `centos.stream9`, `windows.2k25.virtio` |
 | `instanceType` | Definisce la **dimensione** della VM (CPU/RAM) | `s1.small`, `u1.large`, `m1.2xlarge` |
 
 `instanceProfile` non determina l'immagine OS — questa è definita nella risorsa **VMDisk** tramite `source.image.name`. Il profilo serve a caricare i driver e i kernel ottimizzati per il sistema operativo. È principalmente utile per **Windows** (driver virtio). `instanceType` dimensiona le risorse CPU e memoria allocate alla VM.

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/compute/how-to/attach-extra-disk.md
@@ -67,8 +67,8 @@ spec:
   externalPorts:
     - 22
   disks:
-    - vm-system-disk
-    - vm-data-disk
+    - name: vm-system-disk
+    - name: vm-data-disk
   sshKeys:
     - ssh-ed25519 AAAA... user@host
 ```

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/compute/quick-start.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Avvio rapido
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # Creare la vostra prima Macchina Virtuale
 
 Questa guida vi accompagna nella creazione della vostra prima macchina virtuale Hikube in **5 minuti** cronometro!
@@ -96,14 +98,11 @@ spec:
   externalMethod: PortList
   externalPorts:
     - 22
-  running: true
+  runStrategy: Always
   instanceType: u1.xlarge
   instanceProfile: "ubuntu"
   disks:
-    - name: disk-example #Specificare il nome del vostro disco
-  resources:
-    cpu: ""
-    memory: ""
+    - name: disk-example # Nome del VMDisk da collegare
   sshKeys:
     - vostra-chiave-pubblica-qui
   cloudInit: |
@@ -235,10 +234,10 @@ L'eliminazione delle VM e dei dischi è **irreversibile**. Assicuratevi di aver 
 
 <div style={{display: 'flex', gap: '20px', flexWrap: 'wrap'}}>
 
-**📚 Configurazione Avanzata**
+**📚 Configurazione Avanzata**  
 → [API Reference completa](./api-reference.md)
 
-**📖 Architettura Tecnica**
+**📖 Architettura Tecnica**  
 → [Comprendere il funzionamento](./overview.md)
 
 </div>
@@ -250,3 +249,10 @@ L'eliminazione delle VM e dei dischi è **irreversibile**. Assicuratevi di aver 
 - I vostri **dati sono sempre al sicuro** grazie alla replica su 3 datacenter
 - La vostra VM può essere **rilocalizzata automaticamente** in caso di guasto del nodo
 - L'**isolamento totale** garantisce la sicurezza tra tenant
+
+<NavigationFooter
+  nextSteps={[
+    {label: "FAQ", href: "../faq"},
+    {label: "Riferimento API", href: "../api-reference"},
+  ]}
+/>

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/compute/troubleshooting.md
@@ -107,7 +107,7 @@ Questo problema interessa tutte le distribuzioni che utilizzano `systemd-resolve
    ```yaml title="vm.yaml"
    spec:
      disks:
-       - data-volume  # Deve corrispondere a metadata.name del VMDisk
+       - name: data-volume  # Deve corrispondere a metadata.name del VMDisk
    ```
 
 2. Verificate lo stato del VMDisk:
@@ -116,7 +116,7 @@ Questo problema interessa tutte le distribuzioni che utilizzano `systemd-resolve
    kubectl describe vmdisk data-volume
    ```
 
-3. Le storageClass disponibili su Hikube sono: `local`, `replicated` e `replicated-async`. Per una VM (istanza isolata), `replicated` è raccomandato.
+3. Le storageClass disponibili su Hikube sono: `local`, `local-encrypted`, `replicated`, `replicated-encrypted`, `replicated-async`, `replicated-async-encrypted`, `replicated-async-windows` e `replicated-async-windows-encrypted`. Per una VM (istanza isolata), `replicated` è raccomandato.
 
 ---
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/api-reference.md
@@ -5,74 +5,85 @@ title: Riferimento API
 
 # Riferimento API - GPU
 
-Questo riferimento dettaglia le API per utilizzare le GPU su Hikube, sia con macchine virtuali che con cluster Kubernetes.
+Questo riferimento dettaglia l'utilizzo delle GPU su Hikube, sia con macchine virtuali (`VMInstance`) che con cluster Kubernetes gestiti (`Kubernetes`).
+
+---
+
+## 🎮 GPU disponibili
+
+Le GPU sono collegate tramite il loro **nome di risorsa** (`nvidia.com/<modello>`). I modelli disponibili su Hikube:
+
+| GPU | Nome di risorsa | Architettura | Memoria | Uso tipico |
+|-----|------------------|--------------|---------|---------------|
+| **L40S** | `nvidia.com/AD102GL_L40S` | Ada Lovelace | 48 GB GDDR6 | Inferenza, sviluppo, rendering |
+| **A100 PCIe 80 GB** | `nvidia.com/GA100_A100_PCIE_80GB` | Ampere | 80 GB HBM2e | Addestramento ML |
+| **A100 SXM4 80 GB** | `nvidia.com/GA100_A100_SXM4_80GB` | Ampere | 80 GB HBM2e | Addestramento ML (multi-GPU NVLink) |
+| **RTX PRO 6000 Blackwell** | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` | Blackwell | 96 GB GDDR7 | LLM, calcolo intensivo |
+
+:::note Disponibilità
+L'hardware GPU disponibile varia in base alla zona. Verificate le risorse allocabili lato piattaforma prima di pianificare un workload. Il driver NVIDIA richiede **almeno 4 GiB di RAM** sulla VM o sul worker.
+:::
 
 ---
 
 ## 🖥️ GPU con Macchine Virtuali
 
-### **API VirtualMachine**
+Su una VM, la GPU è collegata in **passthrough PCI** (allocazione esclusiva) tramite il campo `gpus` di una risorsa [`VMInstance`](../compute/api-reference.md). Il disco è definito separatamente da una risorsa [`VMDisk`](../compute/api-reference.md#vmdisk).
 
-```yaml
+```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
-#### **Parametri GPU per VM**
+:::warning Errori frequenti
+- La risorsa si chiama **`VMInstance`** (non `VirtualMachine`).
+- Lo stato si controlla tramite **`runStrategy: Always`** (non `running: true`).
+- Il disco **non** è un campo `systemDisk` integrato: create una risorsa `VMDisk` e referenziatela in `disks` (lista di oggetti `{name}`).
+:::
+
+### Parametri GPU per VM
 
 | **Parametro** | **Tipo** | **Descrizione** | **Richiesto** |
 |---------------|----------|-----------------|------------|
-| `gpus` | `[]GPU` | Lista delle GPU da collegare | ✅ |
-| `gpus[].name` | `string` | Tipo di GPU NVIDIA | ✅ |
+| `gpus` | `[]object` | Lista delle GPU da collegare | no |
+| `gpus[].name` | `string` | Nome della risorsa GPU (`nvidia.com/...`) | sì (se `gpus` definito) |
 
-#### **Tipi di GPU Disponibili**
+### Esempio VM GPU completo
 
-```yaml
-# GPU per inferenza e sviluppo
-gpus:
-  - name: "nvidia.com/AD102GL_L40S"
-
-# GPU per addestramento ML
-gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"
-
-# GPU per LLM e calcolo exascale
-gpus:
-  - name: "nvidia.com/H100_94GB"
-```
-
-#### **Specifiche Hardware**
-
-| **GPU** | **Architettura** | **Memoria** | **Prestazioni** |
-|---------|------------------|-------------|-----------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) |
-
-#### **Esempio VM GPU Completo**
-
-```yaml
+```yaml title="ai-workstation.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMDisk
+metadata:
+  name: ai-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMInstance
 metadata:
   name: ai-workstation
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.2xlarge  # 8 vCPU, 32 GB RAM
   gpus:
     - name: "nvidia.com/GA100_A100_PCIE_80GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+  disks:
+    - name: ai-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -83,36 +94,45 @@ spec:
     users:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
-
     packages:
       - python3-pip
       - build-essential
-
     runcmd:
-      # Driver NVIDIA
-      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-      - dpkg -i cuda-keyring_1.0-1_all.deb
+      # Driver NVIDIA + CUDA (vedi la guida dedicata per la versione esatta)
+      - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+      - dpkg -i cuda-keyring_1.1-1_all.deb
       - apt-get update
-      - apt-get install -y cuda-toolkit nvidia-driver-535
-
+      - apt-get install -y cuda-toolkit nvidia-driver-570
       # PyTorch con CUDA
-      - pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu121
+      - pip3 install torch torchvision
+```
+
+### Multi-GPU su VM
+
+```yaml
+spec:
+  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
+  gpus:
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
 ---
 
 ## ☸️ GPU con Kubernetes
 
-### **API Kubernetes con GPU Worker**
+Su un cluster Kubernetes gestito, le GPU sono collegate ai **node group**, e l'addon **`gpuOperator`** deve essere attivato per esporre le GPU ai pod.
 
-```yaml
+```yaml title="cluster-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: cluster-gpu
 spec:
   controlPlane:
-    replicas: 1
+    replicas: 2
 
   nodeGroups:
     gpu-workers:
@@ -122,16 +142,26 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Richiesto: installa i driver NVIDIA e il device plugin
+    gpuOperator:
+      enabled: true
 ```
 
-#### **Parametri GPU per NodeGroup**
+:::warning Addon `gpuOperator` richiesto
+Senza `gpuOperator: enabled: true`, le GPU dei worker non sono esposte ai pod (`nvidia.com/gpu` resta a 0).
+:::
+
+### Parametri GPU per NodeGroup
 
 | **Parametro** | **Tipo** | **Descrizione** | **Richiesto** |
 |---------------|----------|-----------------|------------|
-| `nodeGroups.<name>.gpus` | `[]GPU` | GPU per i worker | ❌ |
-| `gpus[].name` | `string` | Tipo di GPU NVIDIA | ✅ |
+| `nodeGroups.<name>.gpus` | `[]object` | GPU collegate ai worker del gruppo | no |
+| `gpus[].name` | `string` | Nome della risorsa GPU (`nvidia.com/...`) | sì (se `gpus` definito) |
+| `addons.gpuOperator.enabled` | `boolean` | Attiva il NVIDIA GPU Operator | sì (per utilizzare le GPU) |
 
-#### **Configurazione Multi-GPU**
+### Configurazione Multi-GPU per worker
 
 ```yaml
 nodeGroups:
@@ -140,15 +170,17 @@ nodeGroups:
     maxReplicas: 2
     instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
     gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
+      - name: "nvidia.com/GA100_A100_SXM4_80GB"
 ```
 
-#### **Utilizzo nei Pod**
+### Utilizzo nei Pod
 
-```yaml
+Una volta attivo il `gpuOperator`, i pod riservano le GPU tramite la risorsa `nvidia.com/gpu`:
+
+```yaml title="ml-training.yaml"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -156,193 +188,61 @@ metadata:
 spec:
   containers:
   - name: trainer
-    image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+    image: pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
     resources:
       limits:
         nvidia.com/gpu: 1
       requests:
         nvidia.com/gpu: 1
-    command:
-      - python
-      - train.py
-```
-
-#### **Job Multi-GPU**
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: distributed-training
-spec:
-  template:
-    spec:
-      containers:
-      - name: trainer
-        image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
-        resources:
-          limits:
-            nvidia.com/gpu: 4
-          requests:
-            nvidia.com/gpu: 4
-        env:
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0,1,2,3"
-      restartPolicy: Never
+    command: ["python", "train.py"]
 ```
 
 ---
 
-## 📋 Confronto degli Approcci
-
-### **VM GPU vs Kubernetes GPU**
+## 📋 VM GPU vs Kubernetes GPU
 
 | **Aspetto** | **VM GPU** | **Kubernetes GPU** |
 |------------|------------|-------------------|
-| **Allocazione** | 1 GPU = 1 VM (esclusivo) | 1+ GPU per worker (condivisibile) |
-| **Isolamento** | Completo a livello VM | Namespace/Pod |
-| **Scaling** | Verticale (più GPU) | Orizzontale + Verticale |
-| **Gestione** | Manuale tramite YAML | Orchestrata da K8s |
-| **Condivisione** | No | Si (tra pod) |
-| **Overhead** | Minimo | Overhead orchestrazione |
+| **Allocazione** | 1 GPU = 1 VM (passthrough esclusivo) | 1+ GPU per worker |
+| **Isolamento** | Completo a livello VM | Namespace / Pod |
+| **Scaling** | Verticale (più GPU) | Orizzontale + Verticale (autoscaling) |
+| **Gestione** | Manuale tramite `VMInstance` | Orchestrata da Kubernetes |
+| **Condivisione** | No | Sì (tra pod) |
+| **Overhead** | Minimo | Overhead di orchestrazione |
 
-### **Quando utilizzare ciascun approccio**
+**VM GPU**: applicazioni non containerizzate, accesso diretto alla GPU, sviluppo/prototipazione, rendering/CAD.
 
-#### **VM GPU raccomandata per:**
-
-- Applicazioni legacy non containerizzate
-- Necessità di accesso diretto e completo alla GPU
-- Sviluppo e prototipazione
-- Workload monolitici
-- Applicazioni grafiche (rendering, CAD)
-
-#### **Kubernetes GPU raccomandato per:**
-
-- Applicazioni containerizzate
-- Workload che necessitano scaling automatico
-- Job paralleli e distribuiti
-- Condivisione delle risorse GPU
-- Pipeline ML/AI complesse
+**Kubernetes GPU**: workload containerizzati, autoscaling, job paralleli/distribuiti, pipeline ML/AI.
 
 ---
 
-## 🔧 Configurazione Avanzata
+## ✅ Verifica
 
-### **Multi-GPU su VM**
-
-```yaml
-apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
-metadata:
-  name: multi-gpu-vm
-spec:
-  instanceType: u1.8xlarge  # 32 vCPU, 128 GB RAM
-  gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-```
-
-### **NodeGroup specializzato GPU**
-
-```yaml
-nodeGroups:
-  gpu-inference:
-    minReplicas: 2
-    maxReplicas: 10
-    instanceType: "u1.large"
-    gpus:
-      - name: "nvidia.com/AD102GL_L40S"
-
-  gpu-training:
-    minReplicas: 1
-    maxReplicas: 3
-    instanceType: "u1.4xlarge"
-    gpus:
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-      - name: "nvidia.com/GA100_A100_PCIE_80GB"
-```
-
-### **Pod con GPU specifica**
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: specific-gpu-pod
-spec:
-  nodeSelector:
-    gpu-type: "L40S"
-  containers:
-  - name: app
-    image: nvidia/cuda:12.0-runtime-ubuntu20.04
-    resources:
-      limits:
-        nvidia.com/gpu: 1
-```
-
----
-
-## ✅ Verifica e Monitoraggio
-
-### **Verifica VM GPU**
+### VM GPU
 
 ```bash
-# Accedere alla VM
 virtctl ssh ubuntu@vm-gpu
-
-# Verificare le GPU
 nvidia-smi
-
-# Test CUDA
 nvidia-smi --query-gpu=name,memory.total,utilization.gpu --format=csv
 ```
 
-### **Verifica Kubernetes GPU**
+### Kubernetes GPU
 
 ```bash
-# Vedere le risorse GPU sui nodi
-kubectl describe nodes
-
-# Verificare l'allocazione GPU
+# GPU esposte sui nodi (richiede gpuOperator attivo)
 kubectl get nodes -o custom-columns=NAME:.metadata.name,GPU:.status.allocatable.'nvidia\.com/gpu'
 
-# Monitoraggio utilizzo GPU
-kubectl top nodes
-```
-
-### **Monitoraggio GPU in un Pod**
-
-```bash
-# Exec in un pod con GPU
+# Verificare dall'interno di un pod
 kubectl exec -it <pod-name> -- nvidia-smi
-
-# Vedere le metriche GPU
-kubectl exec -it <pod-name> -- nvidia-smi --query-gpu=utilization.gpu,memory.used,memory.total --format=csv -l 5
 ```
 
 ---
 
 ## 💡 Buone Pratiche
 
-### **Per VM GPU:**
-
-- Utilizzate la storage class `replicated` per la produzione
-- Dimensionate CPU/RAM in base alla GPU (rapporto 8-16 vCPU per GPU)
-- Installate i driver NVIDIA tramite cloud-init
-- Fermate le VM quando inutilizzate per ottimizzare i costi
-
-### **Per Kubernetes GPU:**
-
-- Configurate resource limits appropriati
-- Utilizzate nodeSelector o nodeAffinity per indirizzare GPU specifiche
-- Implementate PodDisruptionBudget per i workload critici
-- Monitorate l'utilizzo GPU con metriche personalizzate
-
-### **Generale:**
-
-- L40S per inferenza/sviluppo
-- A100 per addestramento ML standard
-- H100 per LLM e calcolo exascale
-- Testate con L40S prima di passare a GPU più costose
+- **L40S** per l'inferenza e lo sviluppo, **A100** per l'addestramento ML, **RTX PRO 6000 (Blackwell)** per i workload più esigenti.
+- Testate con un L40S prima di riservare le GPU più costose.
+- Dimensionate CPU/RAM in funzione della GPU (≈ 8–16 vCPU per GPU) e prevedete ≥ 4 GiB di RAM.
+- Su VM: installate i driver NVIDIA tramite cloud-init (vedi [Installare i driver CUDA](../compute/how-to/install-cuda-drivers.md)).
+- Su Kubernetes: attivate sempre l'addon `gpuOperator`.
+- Utilizzate la `storageClass` `replicated` in produzione.

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/concepts.md
@@ -15,7 +15,7 @@ graph TB
         subgraph "GPU fisiche"
             G1[NVIDIA L40S]
             G2[NVIDIA A100]
-            G3[NVIDIA H100]
+            G3[NVIDIA RTX PRO 6000<br/>Blackwell]
         end
 
         subgraph "Allocazione VM"
@@ -58,19 +58,20 @@ graph TB
 
 ## Tipi di GPU disponibili
 
-| GPU | Architettura | Memoria | Prestazioni (INT8) | Caso d'uso |
-|-----|-------------|---------|-------------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS | Inferenza, sviluppo, prototipazione |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS | Addestramento ML, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS | LLM, calcolo exascale, addestramento distribuito |
+| GPU | Architettura | Memoria | Caso d'uso |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenza, sviluppo, prototipazione |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | Addestramento ML, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, calcolo intensivo, addestramento distribuito |
 
 ### Identificativi GPU nei manifest
 
-| GPU | Valore `gpus[].name` / `nvidia.com/` |
-|-----|---------------------------------------|
+| GPU | Valore `gpus[].name` |
+|-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ---
 
@@ -93,8 +94,8 @@ Prevedete **da 8 a 16 vCPU per GPU**. Per una singola GPU, un `u1.2xlarge` (8 vC
 
 Le GPU sono esposte ai pod tramite il **NVIDIA Device Plugin**:
 
-- Il GPU Operator deve essere attivato sul cluster (`plugins.gpu-operator.enabled: true`)
-- I pod richiedono una GPU tramite `resources.limits` (es: `nvidia.com/AD102GL_L40S: 1`)
+- Il GPU Operator deve essere attivato sul cluster (`addons.gpuOperator.enabled: true`)
+- I pod richiedono una GPU tramite `resources.limits` (`nvidia.com/gpu: 1`)
 - Lo scheduler Kubernetes posiziona il pod su un nodo che dispone della GPU richiesta
 - I nodi GPU sono configurati nei **node group** con il campo `gpus[]`
 
@@ -108,7 +109,7 @@ graph LR
 
     subgraph "Pod"
         C[Container]
-        RL[resources.limits:<br/>nvidia.com/AD102GL_L40S: 1]
+        RL[resources.limits:<br/>nvidia.com/gpu: 1]
     end
 
     GPU --> DP
@@ -136,8 +137,8 @@ graph LR
 |-----------|--------|
 | GPU per VM | Multipli (secondo disponibilità) |
 | GPU per pod Kubernetes | Multipli (tramite `resources.limits`) |
-| Tipi di GPU | L40S, A100, H100 |
-| Memoria GPU max | 80 GB (A100/H100) |
+| Tipi di GPU | L40S, A100 (PCIe/SXM4), RTX PRO 6000 Blackwell |
+| Memoria GPU max | 96 GB (RTX PRO 6000 Blackwell) |
 
 ---
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/faq.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/faq.md
@@ -7,21 +7,22 @@ title: FAQ
 
 ### Quali modelli di GPU sono disponibili?
 
-Hikube propone tre famiglie di GPU NVIDIA:
+Hikube propone diverse GPU NVIDIA:
 
 | GPU | Architettura | Memoria | Caso d'uso |
 |-----|-------------|---------|-------------|
 | **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenza, rendering grafico |
-| **A100** | Ampere | 80 GB HBM2e | Addestramento ML, calcolo scientifico |
-| **H100** | Hopper | 80 GB HBM3 | LLM, calcolo exascale |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | Addestramento ML, calcolo scientifico |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, calcolo intensivo |
 
 Gli identificativi da utilizzare nei manifest:
 
 ```yaml
 gpus:
-  - name: "nvidia.com/AD102GL_L40S"       # L40S
-  - name: "nvidia.com/GA100_A100_PCIE_80GB" # A100
-  - name: "nvidia.com/H100_94GB"           # H100
+  - name: "nvidia.com/AD102GL_L40S"                                  # L40S
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"                          # A100 PCIe
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"                          # A100 SXM4
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION" # RTX PRO 6000 Blackwell
 ```
 
 ---

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-kubernetes.md
@@ -41,7 +41,16 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+
+  addons:
+    # Richiesto: installa i driver NVIDIA e il device plugin
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` richiesto
+Il collegamento delle GPU ai node group non è sufficiente: senza `addons.gpuOperator.enabled: true`, i driver NVIDIA e il device plugin non sono installati nel cluster tenant, e `nvidia.com/gpu` resta a 0 sui nodi.
+:::
 
 :::tip
 Separate i vostri workload CPU e GPU in node group distinti. Questo permette uno scaling indipendente e un migliore controllo dei costi.
@@ -170,6 +179,10 @@ spec:
       gpus:
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
         - name: "nvidia.com/GA100_A100_PCIE_80GB"
+
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 Per indirizzare un node group specifico nei vostri deployment, utilizzate `nodeSelector`:
@@ -202,7 +215,7 @@ spec:
 ```
 
 :::note
-Le GPU disponibili per Kubernetes sono le stesse delle VM: **L40S** (inferenza/dev), **A100** (addestramento ML) e **H100** (LLM/exascale). Consultate il [riferimento API GPU](../api-reference.md) per le specifiche complete.
+Le GPU disponibili per Kubernetes sono le stesse delle VM: **L40S** (inferenza/dev), **A100 PCIe/SXM4** (addestramento ML) e **RTX PRO 6000 Blackwell** (LLM/calcolo intensivo). Consultate il [riferimento API GPU](../api-reference.md) per i nomi di risorsa esatti e le specifiche.
 :::
 
 ## Verifica

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/how-to/provision-gpu-vm.md
@@ -16,16 +16,16 @@ Hikube permette di collegare una o più GPU NVIDIA direttamente a una macchina v
 
 ### 1. Scegliere il tipo di GPU
 
-Hikube propone tre famiglie di GPU NVIDIA adatte a diversi casi d'uso:
+Hikube propone diverse GPU NVIDIA adatte a diversi casi d'uso:
 
-| GPU | Architettura | Memoria | Prestazioni | Caso d'uso |
-|-----|-------------|---------|-------------|-------------|
-| **L40S** | Ada Lovelace | 48 GB GDDR6 | 362 TOPS (INT8) | Inferenza, sviluppo, prototipazione |
-| **A100** | Ampere | 80 GB HBM2e | 312 TOPS (INT8) | Addestramento ML, fine-tuning |
-| **H100** | Hopper | 80 GB HBM3 | 1979 TOPS (INT8) | LLM, calcolo exascale, addestramento distribuito |
+| GPU | Architettura | Memoria | Caso d'uso |
+|-----|-------------|---------|-------------|
+| **L40S** | Ada Lovelace | 48 GB GDDR6 | Inferenza, sviluppo, prototipazione |
+| **A100 (PCIe / SXM4)** | Ampere | 80 GB HBM2e | Addestramento ML, fine-tuning |
+| **RTX PRO 6000 Blackwell** | Blackwell | 96 GB GDDR7 | LLM, calcolo intensivo, addestramento distribuito |
 
 :::tip Quale GPU scegliere?
-Iniziate con un **L40S** per lo sviluppo e la prototipazione. Passate a un **A100** per l'addestramento di modelli ML standard, e riservate l'**H100** per i workload esigenti come l'addestramento di LLM o il calcolo ad alte prestazioni.
+Iniziate con un **L40S** per lo sviluppo e la prototipazione. Passate a un **A100** per l'addestramento di modelli ML standard, e riservate l'**RTX PRO 6000 (Blackwell)** per i workload più esigenti come l'addestramento di LLM o il calcolo ad alte prestazioni.
 :::
 
 Gli identificativi GPU da utilizzare nei vostri manifest sono:
@@ -33,14 +33,26 @@ Gli identificativi GPU da utilizzare nei vostri manifest sono:
 | GPU | Valore `gpus[].name` |
 |-----|----------------------|
 | L40S | `nvidia.com/AD102GL_L40S` |
-| A100 | `nvidia.com/GA100_A100_PCIE_80GB` |
-| H100 | `nvidia.com/H100_94GB` |
+| A100 PCIe 80 GB | `nvidia.com/GA100_A100_PCIE_80GB` |
+| A100 SXM4 80 GB | `nvidia.com/GA100_A100_SXM4_80GB` |
+| RTX PRO 6000 Blackwell | `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION` |
 
 ### 2. Creare il manifest della VM con GPU
 
 Create un manifest che dichiara la GPU desiderata nella sezione `spec.gpus`:
 
 ```yaml title="gpu-vm.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: gpu-workstation-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 100Gi
+  storageClass: replicated
+---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
@@ -51,9 +63,8 @@ spec:
   instanceType: u1.2xlarge
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 100Gi
-    storageClass: replicated
+  disks:
+    - name: gpu-workstation-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -132,6 +143,17 @@ Per i workload intensivi (addestramento distribuito, inferenza su larga scala), 
 
 ```yaml title="multi-gpu-vm.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: multi-gpu-disk
+spec:
+  source:
+    image:
+      name: ubuntu-2404
+  storage: 200Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
 kind: VMInstance
 metadata:
   name: multi-gpu-workstation
@@ -140,13 +162,12 @@ spec:
   instanceProfile: ubuntu
   instanceType: u1.8xlarge
   gpus:
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-    - name: "nvidia.com/H100_94GB"
-  systemDisk:
-    size: 200Gi
-    storageClass: replicated
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+    - name: "nvidia.com/GA100_A100_SXM4_80GB"
+  disks:
+    - name: multi-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/overview.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/overview.md
@@ -3,6 +3,8 @@ sidebar_position: 1
 title: Panoramica dei GPU
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # GPU su Hikube
 
 Hikube propone l'accesso agli acceleratori **NVIDIA** tramite GPU Passthrough, permettendo l'esecuzione di workload che necessitano di accelerazione hardware. Le GPU sono disponibili per due tipi di workload: macchine virtuali e pod Kubernetes.
@@ -37,28 +39,28 @@ Le GPU possono essere allocate ai worker Kubernetes e poi assegnate ai pod trami
 
 ## 🖥️ Hardware Disponibile
 
-Hikube propone tre tipi di GPU NVIDIA:
+Hikube propone diverse GPU NVIDIA:
 
 ### **NVIDIA L40S**
 
 - **Architettura**: Ada Lovelace
 - **Memoria**: 48 GB GDDR6 con ECC
-- **Prestazioni**: 362 TOPS (INT8), 91.6 TFLOPs (FP32)
-- **Uso tipico**: IA generativa, inferenza, rendering tempo reale
+- **Nome di risorsa**: `nvidia.com/AD102GL_L40S`
+- **Uso tipico**: IA generativa, inferenza, rendering in tempo reale
 
-### **NVIDIA A100**
+### **NVIDIA A100 80 GB (PCIe / SXM4)**
 
 - **Architettura**: Ampere
 - **Memoria**: 80 GB HBM2e con ECC
-- **Prestazioni**: 312 TOPS (INT8), 624 TFLOPs (Tensor)
-- **Uso tipico**: Addestramento ML, calcolo ad alte prestazioni
+- **Nomi di risorsa**: `nvidia.com/GA100_A100_PCIE_80GB`, `nvidia.com/GA100_A100_SXM4_80GB`
+- **Uso tipico**: Addestramento ML, calcolo ad alte prestazioni (la variante SXM4 supporta NVLink per il multi-GPU)
 
-### **NVIDIA H100**
+### **NVIDIA RTX PRO 6000 Blackwell**
 
-- **Architettura**: Hopper
-- **Memoria**: 80 GB HBM3 con ECC
-- **Prestazioni**: 1979 TOPS (INT8), 989 TFLOPs (Tensor)
-- **Uso tipico**: LLM, transformer, calcolo exascale
+- **Architettura**: Blackwell (Server Edition)
+- **Memoria**: 96 GB GDDR7 con ECC
+- **Nome di risorsa**: `nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`
+- **Uso tipico**: LLM, transformer, calcolo intensivo
 
 ---
 
@@ -68,21 +70,21 @@ Hikube propone tre tipi di GPU NVIDIA:
 
 ```mermaid
 flowchart TD
-    subgraph HIKUBE["Infrastructure Hikube"]
-        subgraph NODE["Nœud Physique"]
+    subgraph HIKUBE["Infrastruttura Hikube"]
+        subgraph NODE["Nodo Fisico"]
             GPU1["🎮 GPU L40S"]
             GPU2["🎮 GPU A100"]
-            GPU3["🎮 GPU H100"]
+            GPU3["🎮 GPU RTX PRO 6000"]
         end
-
+        
         subgraph VM1["VM Instance"]
-            APP1["Application GPU"]
+            APP1["Applicazione GPU"]
         end
     end
-
+    
     GPU1 --> VM1
     VM1 --> APP1
-
+    
     style GPU1 fill:#90EE90
     style VM1 fill:#FFE4B5
     style APP1 fill:#ADD8E6
@@ -98,23 +100,23 @@ flowchart TD
             GPU2["🎮 GPU A100"]
             KUBELET["kubelet"]
         end
-
+        
         subgraph POD1["Pod"]
             CONTAINER1["Container GPU"]
         end
-
+        
         subgraph POD2["Pod"]
             CONTAINER2["Container GPU"]
         end
     end
-
+    
     GPU1 --> KUBELET
     GPU2 --> KUBELET
     KUBELET --> POD1
     KUBELET --> POD2
     POD1 --> CONTAINER1
     POD2 --> CONTAINER2
-
+    
     style GPU1 fill:#90EE90
     style GPU2 fill:#90EE90
     style POD1 fill:#FFE4B5
@@ -129,11 +131,14 @@ flowchart TD
 
 ```yaml
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 spec:
+  runStrategy: Always
   instanceType: "u1.xlarge"
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
+  disks:
+    - name: vm-gpu-disk
 ```
 
 ### **GPU su Kubernetes Worker**
@@ -147,6 +152,9 @@ spec:
       instanceType: "u1.xlarge"
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
+  addons:
+    gpuOperator:
+      enabled: true
 ```
 
 ### **GPU in Pod Kubernetes**
@@ -173,7 +181,7 @@ spec:
 | **Prestazioni** | Native (passthrough) | Native (device plugin) |
 | **Gestione** | Manuale | Automatizzata |
 | **Scaling** | Solo verticale | Orizzontale + Verticale |
-| **Condivisione** | No | Si (tra pod) |
+| **Condivisione** | No | Sì (tra pod) |
 | **Complessità** | Semplice | Complessa |
 
 ---
@@ -183,9 +191,19 @@ spec:
 ### **Per le Macchine Virtuali**
 
 - [Creare una VM GPU](./quick-start.md) → Guida pratica
-- [Riferimento API](./api-reference.md) → Configurazione completa
+- [API Reference](./api-reference.md) → Configurazione completa
 
 ### **Per Kubernetes**
 
 - [Cluster GPU](../kubernetes/overview.md) → Worker con GPU
   - [Configurazione avanzata](../kubernetes/api-reference.md) → NodeGroup GPU
+
+<NavigationFooter
+  nextSteps={[
+    {label: "Concetti", href: "../concepts"},
+    {label: "Avvio rapido", href: "../quick-start"},
+  ]}
+  seeAlso={[
+    {label: "Risorse di calcolo", href: "../../compute/"},
+  ]}
+/>

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/gpu/quick-start.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Avvio rapido
 ---
 
+import NavigationFooter from '@site/src/components/NavigationFooter';
+
 # Utilizzare le GPU su Hikube
 
 Questa guida presenta i due metodi di utilizzo delle GPU: con macchine virtuali e con cluster Kubernetes.
@@ -40,18 +42,17 @@ spec:
 
 ```yaml title="vm-gpu.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
-kind: VirtualMachine
+kind: VMInstance
 metadata:
   name: vm-gpu-example
 spec:
-  running: true
+  runStrategy: Always
   instanceProfile: ubuntu
   instanceType: u1.xlarge  # 4 vCPU, 16 GB RAM
   gpus:
     - name: "nvidia.com/AD102GL_L40S"
-  systemDisk:
-    size: 50Gi
-    storageClass: replicated
+  disks:
+    - name: ubuntu-gpu-disk
   external: true
   externalMethod: PortList
   externalPorts:
@@ -64,13 +65,13 @@ spec:
       - name: ubuntu
         sudo: ALL=(ALL) NOPASSWD:ALL
         shell: /bin/bash
-
+    
     package_update: true
     packages:
       - curl
       - wget
       - build-essential
-
+    
     runcmd:
       # Installazione driver NVIDIA
       - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
@@ -87,7 +88,7 @@ kubectl apply -f vm-disk.yaml
 kubectl apply -f vm-gpu.yaml
 
 # Verificare lo stato
-kubectl get virtualmachine vm-gpu-example
+kubectl get vminstance vm-gpu-example
 ```
 
 ### **Passo 4: Accedere e testare**
@@ -114,7 +115,7 @@ metadata:
 spec:
   controlPlane:
     replicas: 1
-
+  
   nodeGroups:
     # Worker GPU
     gpu-nodes:
@@ -124,7 +125,7 @@ spec:
       ephemeralStorage: 100Gi
       gpus:
         - name: "nvidia.com/AD102GL_L40S"
-
+    
     # Worker standard (opzionale)
     standard-nodes:
       minReplicas: 1
@@ -133,7 +134,17 @@ spec:
       ephemeralStorage: 50Gi
 
   storageClass: "replicated"
+
+  addons:
+    # Indispensabile: installa i driver NVIDIA e il device plugin
+    # che espongono nvidia.com/gpu ai pod del cluster tenant
+    gpuOperator:
+      enabled: true
 ```
+
+:::warning Addon `gpuOperator` richiesto
+Senza l'addon `gpuOperator` attivato, le GPU collegate ai worker **non** sono esposte ai pod (`nvidia.com/gpu` resta a 0). Esso installa i driver NVIDIA e il device plugin nel cluster tenant.
+:::
 
 ### **Passo 2: Distribuire il cluster**
 
@@ -209,13 +220,15 @@ kubectl exec -it gpu-test -- nvidia-smi
 gpus:
   - name: "nvidia.com/AD102GL_L40S"  # 48 GB GDDR6
 
-# Per addestramento ML
+# Per addestramento ML (A100, due varianti secondo l'hardware)
 gpus:
-  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e
+  - name: "nvidia.com/GA100_A100_PCIE_80GB"  # 80 GB HBM2e (PCIe)
+  # oppure
+  - name: "nvidia.com/GA100_A100_SXM4_80GB"  # 80 GB HBM2e (SXM4)
 
 # Per LLM/calcolo exascale
 gpus:
-  - name: "nvidia.com/H100_94GB"  # 80 GB HBM3
+  - name: "nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"  # 96 GB GDDR7
 ```
 
 ---
@@ -283,5 +296,15 @@ Queste azioni eliminano le risorse GPU e tutti i dati associati. Queste operazio
 
 - **VM GPU**: Ideale per prototipazione e applicazioni legacy
 - **Kubernetes GPU**: Raccomandato per workload di produzione scalabili
-- Iniziate con **L40S** per testare prima di utilizzare A100/H100
+- Iniziate con **L40S** per testare prima di utilizzare A100 o RTX PRO 6000 (Blackwell)
 - Utilizzate la storage class `replicated` per la produzione
+
+<NavigationFooter
+  nextSteps={[
+    {label: "FAQ", href: "../faq"},
+    {label: "Riferimento API", href: "../api-reference"},
+  ]}
+  seeAlso={[
+    {label: "Risorse di calcolo", href: "../../compute/"},
+  ]}
+/>

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/kubernetes/api-reference.md
@@ -3,205 +3,294 @@ sidebar_position: 6
 title: Riferimento API
 ---
 
-# Esempi Completi
+# Riferimento API – Kubernetes
 
-## **Cluster di Produzione**
+Questo riferimento descrive l'API **`Kubernetes`** di Hikube (`apps.cozystack.io/v1alpha1`), che effettua il provisioning di cluster Kubernetes gestiti (control plane Kamaji + worker KubeVirt). I campi sottostanti corrispondono allo schema realmente esposto dalla piattaforma.
+
+```yaml title="cluster.yaml"
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kubernetes
+metadata:
+  name: my-cluster
+spec:
+  version: v1.35
+  storageClass: replicated
+  controlPlane:
+    replicas: 2
+  nodeGroups:
+    md0:
+      minReplicas: 1
+      maxReplicas: 5
+      instanceType: u1.medium
+      ephemeralStorage: 20Gi
+      roles:
+        - ingress-nginx
+  addons:
+    ingressNginx:
+      enabled: true
+```
+
+---
+
+## Specifica
+
+| Parametro       | Tipo      | Descrizione                                                            | Predefinito  |
+| --------------- | --------- | --------------------------------------------------------------------- | ------------ |
+| `version`       | `string`  | Versione Kubernetes (`major.minor`) — vedi [versioni](#version)       | `v1.35`      |
+| `storageClass`  | `string`  | Classe di archiviazione per i volumi persistenti                      | `replicated` |
+| `host`          | `string`  | Nome host esterno del cluster. Predefinito `<cluster>.<tenant-host>`  | `""`         |
+| `controlPlane`  | `object`  | Configurazione del piano di controllo — vedi [Concetti](concepts.md#control-plane) | `{}` |
+| `nodeGroups`    | `object`  | Mappa dei gruppi di worker — vedi [nodeGroups](#nodegroups)           | vedi predefinito |
+| `addons`        | `object`  | Moduli aggiuntivi del cluster — vedi [addons](#addons)               | `{}`         |
+
+---
+
+## version
+
+`version` seleziona la versione minore di Kubernetes da distribuire.
+
+| Valori supportati |
+| ----------------- |
+| `v1.35` (predefinito), `v1.34`, `v1.33`, `v1.32`, `v1.31`, `v1.30` |
+
+```yaml
+spec:
+  version: v1.34
+```
+
+Vedi la guida [Aggiornare un cluster](how-to/upgrade-cluster.md) per l'avanzamento di versione.
+
+---
+
+## nodeGroups
+
+`nodeGroups` è una **mappa** (`<nome>: {…}`) che descrive i gruppi di worker. Ogni gruppo è soggetto ad autoscaling tra `minReplicas` e `maxReplicas`.
+
+| Campo              | Tipo            | Descrizione                                                       | Predefinito |
+| ------------------ | --------------- | ----------------------------------------------------------------- | ----------- |
+| `minReplicas`      | `integer`       | Numero minimo di nodi (0 = scale-to-zero possibile)              | `0`         |
+| `maxReplicas`      | `integer`       | Numero massimo di nodi                                           | `10`        |
+| `instanceType`     | `string`        | Profilo dei nodi (vedi [tipi di istanze](../compute/api-reference.md#tipi-di-istanze)) | `u1.medium` |
+| `ephemeralStorage` | `int`/`string`  | Dimensione dell'archiviazione effimera per nodo (es: `20Gi`)     | `20Gi`      |
+| `resources`        | `object`        | Override esplicito `cpu` / `memory` per nodo                     | `{}`        |
+| `gpus`             | `[]object`      | GPU collegate ai nodi (`gpus[].name`) — vedi [GPU con Kubernetes](../gpu/api-reference.md) | `[]` |
+| `roles`            | `[]string`      | Ruoli dei nodi (es: `ingress-nginx`)                             | `[]`        |
+
+:::note `ephemeralStorage` è uno scalare
+Indicate direttamente una dimensione (`ephemeralStorage: 20Gi`), non un oggetto `{size: …}`.
+:::
+
+```yaml
+spec:
+  nodeGroups:
+    workers:
+      minReplicas: 1
+      maxReplicas: 10
+      instanceType: u1.xlarge
+      ephemeralStorage: 50Gi
+      roles:
+        - ingress-nginx
+    gpu-workers:
+      minReplicas: 0
+      maxReplicas: 4
+      instanceType: u1.2xlarge
+      ephemeralStorage: 200Gi
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
+```
+
+Vedi [Concetti → Node Groups](concepts.md#node-groups) per il dettaglio dei campi.
+
+---
+
+## addons
+
+Il blocco `addons` attiva i moduli aggiuntivi installati nel cluster tenant. La maggior parte espone `enabled` e `valuesOverride` (override dei valori Helm).
+
+| Addon                  | Campi                                           | Ruolo                                                     |
+| ---------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `certManager`          | `enabled`, `valuesOverride`                     | Gestione automatica dei certificati TLS                   |
+| `ingressNginx`         | `enabled`, `exposeMethod`, `hosts`, `valuesOverride` | Controller Ingress NGINX (vedi sotto)                |
+| `fluxcd`               | `enabled`, `valuesOverride`                     | GitOps (Flux)                                             |
+| `gatewayAPI`           | `enabled`                                       | Supporto della Gateway API                                |
+| `gpuOperator`          | `enabled`, `valuesOverride`                     | NVIDIA GPU Operator (**richiesto** per i worker GPU)      |
+| `monitoringAgents`     | `enabled`, `valuesOverride`                     | Agenti di monitoring/log                                  |
+| `velero`               | `enabled`, `valuesOverride`                     | Backup / ripristino                                       |
+| `cilium`               | `valuesOverride`                                | CNI Cilium (sempre attivo, solo override)                 |
+| `coredns`              | `valuesOverride`                                | CoreDNS (sempre attivo, solo override)                    |
+| `verticalPodAutoscaler`| `valuesOverride`                                | Vertical Pod Autoscaler (sempre attivo)                   |
+
+:::note
+`cilium`, `coredns` e `verticalPodAutoscaler` non hanno un campo `enabled` (componenti di base) — solo `valuesOverride` è utilizzabile. `gatewayAPI` espone solo `enabled`.
+:::
+
+### certManager / fluxcd / velero / monitoringAgents / gpuOperator
+
+```yaml
+spec:
+  addons:
+    certManager:
+      enabled: true
+    gpuOperator:
+      enabled: true     # indispensabile se dei nodeGroups portano delle gpus
+    velero:
+      enabled: true
+    monitoringAgents:
+      enabled: true
+    fluxcd:
+      enabled: true
+```
+
+### ingressNginx
+
+| Campo            | Tipo       | Descrizione                                                                  | Predefinito |
+| ---------------- | ---------- | ---------------------------------------------------------------------------- | ----------- |
+| `enabled`        | `boolean`  | Attiva il controller (richiede nodi con il ruolo `ingress-nginx`)           | `false`     |
+| `exposeMethod`   | `string`   | Metodo di esposizione: `Proxied` o `LoadBalancer`                           | `Proxied`   |
+| `hosts`          | `[]string` | Domini instradati verso questo cluster quando `exposeMethod: Proxied`       | `[]`        |
+| `valuesOverride` | `object`   | Override dei valori Helm                                                     | `{}`        |
+
+```yaml
+spec:
+  addons:
+    ingressNginx:
+      enabled: true
+      exposeMethod: Proxied
+      hosts:
+        - app.example.com
+        - "*.services.example.com"
+```
+
+---
+
+## Esempi completi
+
+### Cluster di produzione
 
 ```yaml title="production-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: production
-  namespace: company-prod
-  labels:
-    environment: production
-    criticality: high
-    team: platform
 spec:
-  # Configurazione cluster
-  host: "k8s-prod.company.com"
-  storageClass: "replicated"
+  version: v1.34
+  storageClass: replicated
+  host: k8s-prod.example.com
 
-  # Piano di controllo ad alta disponibilità
   controlPlane:
     replicas: 3
 
-  # Node group specializzati
   nodeGroups:
-    # Nodi generali con Ingress
     web:
       minReplicas: 3
       maxReplicas: 10
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Nodi compute per workload intensivi
     compute:
       minReplicas: 1
       maxReplicas: 5
-      instanceType: "u1.4xlarge"  # 16 vCPU, 64 GB RAM
+      instanceType: u1.4xlarge
       ephemeralStorage: 100Gi
       roles: []
 
-    # Nodi monitoring dedicati
-    monitoring:
-      minReplicas: 2
-      maxReplicas: 4
-      instanceType: "m1.xlarge"   # 4 vCPU, 32 GB RAM
-      ephemeralStorage: 200Gi
-      roles:
-        - monitoring
-
-  # Add-on completi
   addons:
-    # Certificati SSL automatici
     certManager:
       enabled: true
-      valuesOverride:
-        prometheus:
-          enabled: true
-
-    # Esposizione HTTP/HTTPS
     ingressNginx:
       enabled: true
+      exposeMethod: Proxied
       hosts:
-        - "app.company.com"
-        - "api.company.com"
-        - "*.services.company.com"
-      valuesOverride:
-        controller:
-          replicaCount: 3
-          resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
-
-    # GitOps per le distribuzioni
+        - app.example.com
+        - api.example.com
     fluxcd:
       enabled: true
-      valuesOverride:
-        gitRepository:
-          url: "https://github.com/company/k8s-production"
-          branch: "main"
-
-    # Monitoring completo
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        fluentbit:
-          enabled: true
+    velero:
+      enabled: true
 ```
 
-## **Cluster di Sviluppo**
+### Cluster di sviluppo
 
 ```yaml title="development-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: development
-  namespace: company-dev
-  labels:
-    environment: development
-    auto-cleanup: "7d"
 spec:
-  # Configurazione base
-  host: "k8s-dev.company.local"
-  storageClass: "replicated"
+  storageClass: replicated
 
-  # Piano di controllo minimale
   controlPlane:
-    replicas: 1  # Risparmio di risorse
+    replicas: 1   # risparmio di risorse (nessuna HA)
 
-  # Node group unico polivalente
   nodeGroups:
     general:
       minReplicas: 1
       maxReplicas: 3
-      instanceType: "s1.medium"
+      instanceType: s1.medium
       ephemeralStorage: 30Gi
       roles:
         - ingress-nginx
 
-  # Solo add-on essenziali
   addons:
     certManager:
       enabled: true
-
     ingressNginx:
       enabled: true
       hosts:
-        - "*.dev.company.local"
-      valuesOverride:
-        controller:
-          replicaCount: 1  # Replica minimale
+        - "*.dev.example.com"
 ```
 
-## **Cluster ML/AI con GPU**
+### Cluster ML/AI con GPU
 
 ```yaml title="ml-cluster.yaml"
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Kubernetes
 metadata:
   name: machine-learning
-  namespace: company-ai
-  labels:
-    environment: ai
-    workload: gpu
 spec:
-  host: "k8s-ai.company.com"
-  storageClass: "fast-ssd"  # Archiviazione ad alte prestazioni
+  storageClass: replicated
 
   controlPlane:
     replicas: 2
 
   nodeGroups:
-    # Nodi standard per l'orchestrazione
     system:
       minReplicas: 2
       maxReplicas: 4
-      instanceType: "s1.large"
+      instanceType: s1.large
       ephemeralStorage: 50Gi
       roles:
         - ingress-nginx
-
-    # Nodi GPU per workload ML
     gpu:
-      minReplicas: 0      # Scaling a zero possibile
+      minReplicas: 0          # scale-to-zero fuori carico
       maxReplicas: 10
-      instanceType: "u1.2xlarge"
-      gpus: # Istanza con GPU
-        - name: nvidia.com/AD102GL_L40S # Nvidia L40S
-      ephemeralStorage: 500Gi      # Archiviazione importante per i dataset
+      instanceType: u1.2xlarge
+      ephemeralStorage: 500Gi # dataset
+      gpus:
+        - name: nvidia.com/AD102GL_L40S
       roles: []
 
   addons:
     certManager:
       enabled: true
-
+    # Richiesto per esporre le GPU ai pod (nvidia.com/gpu)
+    gpuOperator:
+      enabled: true
     monitoringAgents:
       enabled: true
-      valuesOverride:
-        # Monitoring specializzato GPU
-        dcgmExporter:
-          enabled: true
 ```
 
----
-
-:::tip 💡 Buone Pratiche
-
-- **Utilizzate le label** per organizzare i vostri cluster per ambiente
-- **Configurate RBAC** fin dalla creazione per proteggere l'accesso
-- **Attivate il monitoring** per un'osservabilità completa
-- **Pianificate la capacità** con node group appropriati
-- **Testate i backup** regolarmente
+:::tip Buone pratiche
+- `controlPlane.replicas: 3` in produzione (quorum etcd / HA).
+- Separate i workload in node group dedicati (web, compute, GPU).
+- Per le GPU: node group con `gpus` **e** `addons.gpuOperator.enabled: true`.
+- Attivate il monitoring e i backup (Velero) sui cluster critici.
 :::
 
-:::warning ⚠️ Attenzione
-
-- **Le eliminazioni sono irreversibili** - pensate ai backup
-- **Gli aggiornamenti** possono avere un impatto sui workload
-- **Verificate la compatibilità** degli add-on con le versioni Kubernetes
+:::warning Attenzione
+- Le eliminazioni di cluster sono **irreversibili** — verificate i vostri backup.
+- Senza l'addon `gpuOperator`, le GPU collegate ai worker non vengono esposte ai pod.
 :::

--- a/i18n/it/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/services/kubernetes/concepts.md
@@ -97,8 +97,8 @@ Questa architettura garantisce:
 
 - **Alta disponibilità** del cluster Kubernetes.
 - **Resilienza geografica** grazie alla replica inter-regioni.
-- **Integrita dei dati** tramite etcd e l'archiviazione persistente.
-- **Scalabilita** orizzontale con i Node Groups.
+- **Integrità dei dati** tramite etcd e l'archiviazione persistente.
+- **Scalabilità** orizzontale con i Node Groups.
 
 ---
 
@@ -137,15 +137,15 @@ controlPlane:
 
 ### `apiServer` (Object)
 
-L'`apiServer` e il componente centrale del piano di controllo Kubernetes.
+L'`apiServer` è il componente centrale del piano di controllo Kubernetes.
 Gestisce tutte le richieste verso l'API Kubernetes e garantisce la comunicazione tra i componenti interni del cluster.
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
-| `resources` | Object | Si | Definisce le risorse CPU e memoria allocate all'API Server |
+| `resources` | Object | Sì | Definisce le risorse CPU e memoria allocate all'API Server |
 | `resources.cpu` | string | No | Numero di vCPU attribuiti (es: `2`) |
-| `resources.memory` | string | No | Quantita di memoria allocata (es: `4Gi`) |
-| `resourcesPreset` | string | Si | Profilo di risorse predefinito (`nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`) |
+| `resources.memory` | string | No | Quantità di memoria allocata (es: `4Gi`) |
+| `resourcesPreset` | string | Sì | Profilo di risorse predefinito (`nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`) |
 
 ### `controllerManager` (Object)
 
@@ -154,10 +154,10 @@ Garantisce la creazione, l'aggiornamento e l'eliminazione delle risorse (pod, se
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
-| `resources` | Object | Si | Specifica le risorse CPU/memoria per il Controller Manager |
+| `resources` | Object | Sì | Specifica le risorse CPU/memoria per il Controller Manager |
 | `resources.cpu` | string | No | Numero di vCPU riservati |
-| `resources.memory` | string | No | Quantita di memoria allocata |
-| `resourcesPreset` | string | Si | Dimensione predefinita (`nano`, `micro`, `small`, `medium`, ecc.) |
+| `resources.memory` | string | No | Quantità di memoria allocata |
+| `resourcesPreset` | string | Sì | Dimensione predefinita (`nano`, `micro`, `small`, `medium`, ecc.) |
 
 ### `konnectivity` (Object)
 
@@ -166,21 +166,21 @@ Sostituisce il vecchio `kube-proxy` per le connessioni in uscita dei nodi e otti
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
-| `server.resources` | Object | Si | Specifica le risorse CPU/memoria del server Konnectivity |
+| `server.resources` | Object | Sì | Specifica le risorse CPU/memoria del server Konnectivity |
 | `server.resources.cpu` | string | No | Numero di vCPU |
-| `server.resources.memory` | string | No | Quantita di memoria |
-| `server.resourcesPreset` | string | Si | Profilo predefinito (`nano`, `micro`, `small`, `medium`, ecc.) |
+| `server.resources.memory` | string | No | Quantità di memoria |
+| `server.resourcesPreset` | string | Sì | Profilo predefinito (`nano`, `micro`, `small`, `medium`, ecc.) |
 
 ### `scheduler` (Object)
 
-Lo `scheduler` determina su quale nodo ogni pod deve essere eseguito in base ai vincoli di risorse, affinita e topologie.
+Lo `scheduler` determina su quale nodo ogni pod deve essere eseguito in base ai vincoli di risorse, affinità e topologie.
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
-| `resources` | Object | Si | Definisce le risorse allocate allo Scheduler |
+| `resources` | Object | Sì | Definisce le risorse allocate allo Scheduler |
 | `resources.cpu` | string | No | Numero di vCPU |
-| `resources.memory` | string | No | Quantita di memoria |
-| `resourcesPreset` | string | Si | Dimensione predefinita (`nano`, `micro`, `small`, `medium`, ecc.) |
+| `resources.memory` | string | No | Quantità di memoria |
+| `resourcesPreset` | string | Sì | Dimensione predefinita (`nano`, `micro`, `small`, `medium`, ecc.) |
 
 ### `replicas` (integer)
 
@@ -205,7 +205,7 @@ resourcesPreset: "2xlarge"  # 4 CPU, 8 GiB RAM
 - Definire sempre `replicas: 3` per la ridondanza.
 - Utilizzare `resourcesPreset` coerenti tra i componenti.
 - Adattare le risorse in base al carico (cluster di produzione → `medium` o `large`).
-- Non sottodimensionare `apiServer`, e il componente più sollecitato.
+- Non sottodimensionare `apiServer`, è il componente più sollecitato.
 :::
 
 ---
@@ -213,16 +213,15 @@ resourcesPreset: "2xlarge"  # 4 CPU, 8 GiB RAM
 ## Node Groups
 
 Il campo `nodeGroup` definisce la configurazione di un gruppo di nodi (worker) all'interno del cluster Kubernetes.
-Permette di specificare il tipo di istanza, le risorse, il numero di repliche, nonche i ruoli e le GPU associate.
+Permette di specificare il tipo di istanza, le risorse, il numero di repliche, nonché i ruoli e le GPU associate.
 
 ```yaml title="node-group.yaml"
-nodeGroup:
+nodeGroups:
   <name>:
-    ephemeralStorage:
-      size: 100Gi
+    ephemeralStorage: 100Gi
     gpus:
       - name: nvidia.com/AD102GL_L40S
-    instanceType: m5.large
+    instanceType: u1.xlarge
     maxReplicas: 5
     minReplicas: 2
     resources:
@@ -234,10 +233,10 @@ nodeGroup:
 
 ---
 
-### `ephemeralStorage` (Object)
+### `ephemeralStorage` (string)
 
-Definisce la configurazione dell'**archiviazione effimera** associata ai nodi del gruppo.
-Questa archiviazione e utilizzata per dati temporanei, cache o file di log.
+Definisce la dimensione dell'**archiviazione effimera** per nodo del gruppo (es: `100Gi`).
+Questa archiviazione è utilizzata per dati temporanei, cache o file di log. È un valore scalare (non un oggetto `{size: …}`).
 
 ### `gpus` (Array)
 
@@ -245,7 +244,7 @@ Elenca le **GPU** disponibili sui nodi del gruppo, utilizzate per carichi di lav
 
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
-| `name` | string | Si | Nome della GPU o tipo di scheda (`nvidia.com/AD102GL_L40S` o `nvidia.com/GA100_A100_PCIE_80GB`) |
+| `name` | string | Sì | Nome della GPU o tipo di scheda (`nvidia.com/AD102GL_L40S` o `nvidia.com/GA100_A100_PCIE_80GB`) |
 
 ### `instanceType` (string)
 
@@ -304,7 +303,7 @@ Definisce le **risorse allocate** a ciascun nodo del gruppo (CPU e memoria).
 | Campo | Tipo | Obbligatorio | Descrizione |
 |-------|------|--------------|-------------|
 | `cpu` | string | No | Numero di vCPU attribuiti per nodo (es: `4`) |
-| `memory` | string | No | Quantita di memoria allocata per nodo (es: `16Gi`) |
+| `memory` | string | No | Quantità di memoria allocata per nodo (es: `16Gi`) |
 
 ### `roles` (Array)
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/tools/terraform.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/tools/terraform.md
@@ -47,18 +47,18 @@ provider "kubectl" {
 
 ```hcl title="variables.tf"
 variable "ssh_public_key" {
-  description = "Clé SSH publique pour l'accès aux VMs"
+  description = "Chiave SSH pubblica per l'accesso alle VM"
   type        = string
 }
 
 variable "cluster_name" {
-  description = "Nom du cluster Kubernetes"
+  description = "Nome del cluster Kubernetes"
   type        = string
   default     = "terraform-cluster"
 }
 
 variable "vm_name" {
-  description = "Nom de la machine virtuelle"
+  description = "Nome della macchina virtuale"
   type        = string
   default     = "terraform-vm"
 }
@@ -80,6 +80,9 @@ resource "kubectl_manifest" "kubernetes_cluster" {
       namespace = "default"
     }
     spec = {
+      version      = "v1.34"
+      storageClass = "replicated"
+
       controlPlane = {
         replicas = 2
       }
@@ -90,11 +93,18 @@ resource "kubectl_manifest" "kubernetes_cluster" {
           maxReplicas      = 5
           instanceType     = "s1.large"
           ephemeralStorage = "50Gi"
-          roles = ["ingress-nginx"]
+          roles            = ["ingress-nginx"]
         }
+        # Esempio di gruppo GPU (richiede l'addon gpuOperator qui sotto)
+        # gpu = {
+        #   minReplicas      = 0
+        #   maxReplicas      = 4
+        #   instanceType     = "u1.2xlarge"
+        #   ephemeralStorage = "200Gi"
+        #   gpus             = [{ name = "nvidia.com/AD102GL_L40S" }]
+        #   roles            = []
+        # }
       }
-
-      storageClass = "replicated"
 
       addons = {
         certManager = {
@@ -106,22 +116,26 @@ resource "kubectl_manifest" "kubernetes_cluster" {
             "${var.cluster_name}.example.com"
           ]
         }
+        # Richiesto per esporre le GPU ai pod di un gruppo di nodi GPU
+        # gpuOperator = {
+        #   enabled = true
+        # }
       }
     }
   })
 }
 
-# Récupérer le kubeconfig
+# Recuperare il kubeconfig
 data "kubernetes_secret" "cluster_kubeconfig" {
   depends_on = [kubectl_manifest.kubernetes_cluster]
-
+  
   metadata {
     name      = "${var.cluster_name}-admin-kubeconfig"
     namespace = "default"
   }
 }
 
-# Sauvegarder le kubeconfig
+# Salvare il kubeconfig
 resource "local_file" "kubeconfig" {
   content = base64decode(
     data.kubernetes_secret.cluster_kubeconfig.data["super-admin.conf"]
@@ -134,22 +148,45 @@ resource "local_file" "kubeconfig" {
 ### Distribuire una Macchina Virtuale
 
 ```hcl title="virtual-machine.tf"
-resource "kubectl_manifest" "virtual_machine" {
+# Il disco è una risorsa VMDisk separata, referenziata dalla VM
+resource "kubectl_manifest" "vm_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "${var.vm_name}-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "50Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "virtual_machine" {
+  depends_on = [kubectl_manifest.vm_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = var.vm_name
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
 
-      systemDisk = {
-        size         = "50Gi"
-        storageClass = "replicated"
-      }
+      disks = [
+        {
+          name = "${var.vm_name}-disk"
+        }
+      ]
 
       external       = true
       externalMethod = "PortList"
@@ -165,14 +202,14 @@ resource "kubectl_manifest" "virtual_machine" {
             shell: /bin/bash
             ssh_authorized_keys:
               - ${var.ssh_public_key}
-
+        
         package_update: true
         packages:
           - curl
           - wget
           - git
           - docker.io
-
+        
         runcmd:
           - systemctl enable docker
           - systemctl start docker
@@ -186,28 +223,52 @@ resource "kubectl_manifest" "virtual_machine" {
 ### Distribuire una VM con GPU
 
 ```hcl title="vm-gpu.tf"
-resource "kubectl_manifest" "vm_gpu" {
+resource "kubectl_manifest" "vm_gpu_disk" {
   yaml_body = yamlencode({
     apiVersion = "apps.cozystack.io/v1alpha1"
-    kind       = "VirtualMachine"
+    kind       = "VMDisk"
+    metadata = {
+      name = "gpu-vm-disk"
+    }
+    spec = {
+      source = {
+        image = {
+          name = "ubuntu-2404"
+        }
+      }
+      storage      = "100Gi"
+      storageClass = "replicated"
+    }
+  })
+}
+
+resource "kubectl_manifest" "vm_gpu" {
+  depends_on = [kubectl_manifest.vm_gpu_disk]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps.cozystack.io/v1alpha1"
+    kind       = "VMInstance"
     metadata = {
       name = "gpu-vm"
     }
     spec = {
-      running         = true
+      runStrategy     = "Always"
       instanceProfile = "ubuntu"
       instanceType    = "u1.xlarge"
 
       gpus = [
         {
+          # Modelli: nvidia.com/AD102GL_L40S, nvidia.com/GA100_A100_PCIE_80GB,
+          # nvidia.com/GA100_A100_SXM4_80GB, nvidia.com/GB202GL_RTX_PRO_6000_BLACKWELL_SERVER_EDITION
           name = "nvidia.com/AD102GL_L40S"
         }
       ]
 
-      systemDisk = {
-        size         = "100Gi"
-        storageClass = "replicated"
-      }
+      disks = [
+        {
+          name = "gpu-vm-disk"
+        }
+      ]
 
       external       = true
       externalMethod = "PortList"
@@ -221,15 +282,15 @@ resource "kubectl_manifest" "vm_gpu" {
           - name: ubuntu
             sudo: ALL=(ALL) NOPASSWD:ALL
             shell: /bin/bash
-
+        
         package_update: true
         packages:
           - curl
           - wget
           - build-essential
-
+        
         runcmd:
-          # Installation pilotes NVIDIA
+          # Installazione driver NVIDIA
           - wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
           - dpkg -i cuda-keyring_1.0-1_all.deb
           - apt-get update
@@ -256,13 +317,13 @@ resource "kubectl_manifest" "postgres" {
       size         = "20Gi"
       replicas     = 2
       storageClass = "replicated"
-
+      
       users = {
         admin = {
           password = var.postgres_password
         }
       }
-
+      
       databases = {
         myapp = {
           roles = {
@@ -275,7 +336,7 @@ resource "kubectl_manifest" "postgres" {
 }
 
 variable "postgres_password" {
-  description = "Password for PostgreSQL admin user"
+  description = "Password per l'utente admin di PostgreSQL"
   type        = string
   sensitive   = true
 }
@@ -289,17 +350,17 @@ variable "postgres_password" {
 
 ```hcl title="outputs.tf"
 output "cluster_kubeconfig" {
-  description = "Chemin vers le kubeconfig du cluster"
+  description = "Percorso del kubeconfig del cluster"
   value       = local_file.kubeconfig.filename
 }
 
 output "vm_status" {
-  description = "Commande pour vérifier le statut de la VM"
-  value       = "kubectl get virtualmachine ${var.vm_name}"
+  description = "Comando per verificare lo stato della VM"
+  value       = "kubectl get vminstance ${var.vm_name}"
 }
 
 output "postgres_connection" {
-  description = "Commande pour se connecter à PostgreSQL"
+  description = "Comando per connettersi a PostgreSQL"
   value       = "kubectl exec -it postgres-terraform-postgres-0 -- psql -U admin -d myapp"
   sensitive   = true
 }
@@ -308,14 +369,14 @@ output "postgres_connection" {
 ### File terraform.tfvars
 
 ```hcl title="terraform.tfvars"
-# Configuration de base
+# Configurazione di base
 cluster_name = "my-prod-cluster"
 vm_name      = "my-app-vm"
 
-# Votre clé SSH publique
+# La vostra chiave SSH pubblica
 ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQ... user@hostname"
 
-# Mot de passe PostgreSQL
+# Password PostgreSQL
 postgres_password = "your-secure-password-here"
 ```
 


### PR DESCRIPTION
## Contexte

Les PRs #67 (compute), #68 (GPU), #69 (Kubernetes) et #70 (Terraform) ont été **mergées** en ne contenant que le contenu **français**. Les traductions **en / de / it** correspondantes étaient restées sur les branches et n'ont pas été intégrées. Cette PR les apporte, régénérées à partir du FR mergé.

Sans elle, les pages traduites affichent encore l'ancienne API erronée (`VirtualMachine`, `running`, `systemDisk`, GPU **H100** inexistant, `fast-ssd`, `ephemeralStorage: {size}`…).

## Contenu — 45 fichiers (15 par langue)

| Ressource | Fichiers (× en/de/it) |
|-----------|------------------------|
| **Compute** | api-reference, quick-start, faq, troubleshooting, how-to/attach-extra-disk |
| **GPU** | api-reference, quick-start, concepts, overview, faq, how-to/provision-gpu-vm, how-to/provision-gpu-kubernetes |
| **Kubernetes** | api-reference, concepts |
| **Terraform** | tools/terraform |

## Méthode

- Traductions régénérées depuis le **nouveau FR** (et non patchées), donc débarrassées des anciens bugs (kind `VMInstance`, `runStrategy`, `disks: [{name}]`, `storage`, vrais GPU L40S/A100 PCIe·SXM4/RTX PRO 6000 Blackwell, addon `gpuOperator`, 8 storageClass…).
- Code/YAML/identifiants/frontmatter préservés verbatim ; seules les proses, titres, cellules de tableau et commentaires de code sont traduits.
- **Ancres internes repointées** sur les slugs traduits par langue (ex. `#types-dinstances` → `#instance-types` / `#instanztypen` / `#tipi-di-istanze` ; liens croisés `concepts.md#control-plane`, `../compute/api-reference.md#vmdisk`).

## Validation

Build Docusaurus relancé : **aucun lien/ancre cassé** sur les pages concernées dans les 4 locales. (L'échec de génération de la locale `de` reste préexistant — métadonnées blog/getting-started manquantes côté traductions, hors périmètre.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)